### PR TITLE
feat: DidExchange allows establishing did-connection through the router

### DIFF
--- a/cmd/user-agent/src/pages/Connections.vue
+++ b/cmd/user-agent/src/pages/Connections.vue
@@ -24,6 +24,45 @@ SPDX-License-Identifier: Apache-2.0
                 <div class="md-layout-item">
                     <md-card class="md-card-plain">
                         <md-card-header data-background-color="green">
+                            <h4 class="title">Router</h4>
+                        </md-card-header>
+                        <md-card-content v-if="!routerConnID" style="background-color: white;">
+                            <md-field>
+                                <label>Router URL</label>
+                                <md-input placeholder="http://router.example.com" v-model="routerURL"
+                                          required></md-input>
+                            </md-field>
+                            <div style="display: flow-root">
+                                <span class="error" v-if="routerRegisterError">{{ routerRegisterError }}</span>
+                                <md-button v-bind:disabled="routerDisabledButton"
+                                           class="md-button md-info md-square right"
+                                           id='routerRegister'
+                                           v-on:click="routerRegister">
+                                    <b>Register</b>
+                                </md-button>
+                            </div>
+                        </md-card-content>
+                        <md-card-content v-if="routerConnID" style="background-color: white;">
+                            <div class="md-layout router">
+                                <div class="md-layout-item md-layout">
+                                    <div class="md-layout-item router-done">
+                                        <div>Router is registered</div>
+                                    </div>
+                                    <div class="md-layout-item">
+                                        <md-button class="md-button md-danger md-square right"
+                                                   id='routerUnregister'
+                                                   v-on:click="routerUnregister">
+                                            <b>Unregister</b>
+                                        </md-button>
+                                    </div>
+                                </div>
+                            </div>
+                        </md-card-content>
+                    </md-card>
+                </div>
+                <div class="md-layout-item">
+                    <md-card class="md-card-plain">
+                        <md-card-header data-background-color="green">
                             <h4 class="title">Create Invitation</h4>
                         </md-card-header>
                         <md-card-content style="background-color: white;">
@@ -78,12 +117,22 @@ SPDX-License-Identifier: Apache-2.0
                         <div class="text-center" v-if="connections.length===0">No connections</div>
                         <md-content class="md-content-connections md-scrollbar">
                             <md-list class="md-triple-line">
-                                <md-list-item v-for="connection in connections" :key="connection.id">
+                                <md-list-item v-for="conn in connections" :key="conn.id">
                                     <div class="md-list-item-text">
-                                        <span>ConnectionID: {{connection.ConnectionID}}</span>
-                                        <span>State: {{connection.State}}</span>
-                                        <span>MyDID: {{connection.MyDID}}</span>
+                                        <span>ConnectionID: {{conn.ConnectionID}}</span>
+                                        <span>State: {{conn.State}}</span>
+                                        <span>MyDID: {{conn.MyDID}}</span>
                                     </div>
+                                    <md-button v-if="canAcceptInvitation(conn)"
+                                               v-on:click="acceptInvitation(conn.ConnectionID)"
+                                               class="md-icon-button md-dense md-raised md-info right">
+                                        <md-icon>done</md-icon>
+                                    </md-button>
+                                    <md-button v-if="canAcceptExchangeRequest(conn)"
+                                               v-on:click="acceptExchangeRequest(conn.ConnectionID)"
+                                               class="md-icon-button md-dense md-raised md-info right">
+                                        <md-icon>done</md-icon>
+                                    </md-button>
                                 </md-list-item>
                             </md-list>
                         </md-content>
@@ -95,14 +144,114 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
+    import axios from "axios";
     export default {
         beforeCreate: async function () {
             window.$aries = await this.$arieslib
             await this.queryConnections()
+            await this.isRouterRegistered()
         },
         methods: {
+            waitFor: function (connection, state, callback) {
+                return new Promise((resolve, reject) => {
+                    const stop = window.$aries.startNotifier(notice => {
+                        if (connection !== notice.payload.connection_id) {
+                            return
+                        }
+
+                        if (notice.payload.state !== state) {
+                            return
+                        }
+
+                        stop()
+
+                        try {
+                            callback().then(() => {
+                                resolve()
+                            })
+                        } catch (err) {
+                            reject(err)
+                        }
+                    }, ["all"])
+
+                    setTimeout(() => {
+                        stop()
+                        reject(new Error("time out while waiting for connection"))
+                    }, 5000)
+                })
+            },
+            isRouterRegistered: async function () {
+                let res = await window.$aries.router.getConnection().catch(err => {
+                    if (!err.message.includes("router not registered")) {
+                        throw err
+                    }
+                })
+
+                if (res) {
+                    this.routerConnID = res.connectionID
+                }
+
+                return this.routerConnID
+            },
+            routerRegister: async function () {
+                this.routerDisabledButton = true
+                this.routerRegisterError = ""
+                let routerURL = this.routerURL.trim().replace(/\/$/, "");
+                if (routerURL.length === 0) {
+                    this.routerRegisterError = "Please fill in the field!"
+                    return
+                }
+
+
+                try {
+                    let invitation = await axios.post(routerURL + "/connections/create-invitation")
+                    let connection = await window.$aries.didexchange.receiveInvitation(invitation.data.invitation)
+
+                    await this.waitFor(connection.connection_id, 'invited', function () {
+                        return window.$aries.didexchange.acceptInvitation({
+                            id: connection.connection_id
+                        })
+                    })
+
+                    await this.waitFor(connection.connection_id, 'completed', function () {
+                        return window.$aries.router.register({"connectionID": connection.connection_id})
+                    })
+                } catch (e) {
+                    this.routerRegisterError = e.message
+                }
+
+                this.routerDisabledButton = false
+                if (await this.isRouterRegistered()) {
+                    await this.queryConnections()
+                }
+            },
+            routerUnregister: async function () {
+                await window.$aries.router.unregister({id: this.routerConnID})
+                this.routerConnID = ""
+            },
+            canAcceptInvitation: function (conn) {
+                return conn.State === 'invited'
+            },
+            canAcceptExchangeRequest: function (conn) {
+                return conn.State === 'requested' && conn.Namespace === 'their'
+            },
+            acceptInvitation: async function (id) {
+                await window.$aries.didexchange.acceptInvitation({
+                    id: id
+                }).then(this.queryConnections)
+            },
+            acceptExchangeRequest: async function (id) {
+                await window.$aries.didexchange.acceptExchangeRequest({
+                    id: id
+                }).then(this.queryConnections)
+            },
             createInvitation: async function () {
                 this.createInvitationError = ""
+                if (!this.routerConnID) {
+                    this.createInvitationError = "Please register a router first!"
+                    return
+                }
+
                 if (this.alias.trim().length === 0) {
                     this.createInvitationError = "Please fill in the field!"
                     return
@@ -139,6 +288,7 @@ SPDX-License-Identifier: Apache-2.0
                         "Invitation received!",
                         `Your connection ID is ${res['connection_id']}`
                     )
+                    await this.queryConnections()
                 } catch (e) {
                     this.receiveInvitationError = e.message
                 }
@@ -166,17 +316,27 @@ SPDX-License-Identifier: Apache-2.0
                 dialogContent: "",
                 invitation: "",
                 alias: "",
+                routerURL: "",
                 connections: [],
+                routerConnID: "",
+                routerDisabledButton: false,
                 createInvitationError: "",
                 receiveInvitationError: "",
+                routerRegisterError: "",
             };
         },
     }
 </script>
 
-<style>
-    .refresh-connections {
-        top: -28px;
+<style scoped>
+    .md-list {
+        width: 100%;
+        display: inline-block;
+        vertical-align: center;
+    }
+
+    .title {
+        display: -webkit-inline-box;
     }
 
     .right {
@@ -185,6 +345,15 @@ SPDX-License-Identifier: Apache-2.0
 
     .error {
         color: red;
+    }
+
+    .router-done {
+        display: flex;
+        align-items: center;
+    }
+
+    .router .md-layout-item {
+        padding: 0;
     }
 
     .md-content-connections {


### PR DESCRIPTION
This PR includes:
*  Register/Unregister the router (form on UI)
* allows accepting the invitation (button on UI)
* allows accepting the exchange request (button on UI)

NOTE: need to deploy a router

![Screenshot_20200508_230713](https://user-images.githubusercontent.com/12339578/81445530-b57e8d80-9181-11ea-9f93-69f6d5c1a025.png)
![Screenshot_20200509_132838](https://user-images.githubusercontent.com/12339578/81471456-ea2e2b80-91f9-11ea-9445-1d3836d8d37f.png)
![Screenshot_20200509_132936](https://user-images.githubusercontent.com/12339578/81471457-eac6c200-91f9-11ea-8960-4e702874232e.png)

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>