### PR TITLE
feat: web wallet login/logout/register/uniregister

### DIFF
--- a/cmd/user-agent/src/pages/DIDManagement.vue
+++ b/cmd/user-agent/src/pages/DIDManagement.vue
@@ -228,7 +228,7 @@ SPDX-License-Identifier: Apache-2.0
                 }
 
                 // saving did metadata
-                this.didManager.storeDIDMetadata(did.id, {
+                await this.didManager.storeDIDMetadata(did.id, {
                     signatureType: this.signType,
                     friendlyName: this.friendlyName
                 })
@@ -287,7 +287,7 @@ SPDX-License-Identifier: Apache-2.0
                     console.error("failed to save the did", e)
                 }
 
-                this.didManager.storeDIDMetadata(resp.did.id, {
+                await this.didManager.storeDIDMetadata(resp.did.id, {
                     signatureType: this.selectSignKey,
                     keyID: this.keyID,
                     friendlyName: this.anyDIDFriendlyName

--- a/cmd/user-agent/src/pages/chapi/wallet/common/keyValStore.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/common/keyValStore.js
@@ -5,7 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 
-
 /**
  * KeyValueStore is key value based store
  * @class
@@ -76,29 +75,60 @@ export class KeyValueStore {
         });
     }
 
-    store(id, value) {
-        var openDB = indexedDB.open(this.dbName, 1);
-
+    async store(id, value) {
+        const dbName = this.dbName
         const storeName = this.storeName
 
-        openDB.onupgradeneeded = function () {
-            var db = {}
-            db.result = openDB.result;
-            db.store = db.result.createObjectStore(storeName, {keyPath: "id"});
-        };
+        return new Promise(function (resolve){
+            var openDB = indexedDB.open(dbName, 1);
 
-        if (!value.id) {
-            value.id = id
-        }
+            openDB.onupgradeneeded = function () {
+                var db = {}
+                db.result = openDB.result;
+                db.store = db.result.createObjectStore(storeName, {keyPath: "id"});
+            };
 
-        openDB.onsuccess = function () {
-            var db = {};
-            db.result = openDB.result;
-            db.tx = db.result.transaction(storeName, "readwrite");
-            db.store = db.tx.objectStore(storeName);
-            db.store.put(value);
-        }
+            if (!value.id) {
+                value.id = id
+            }
 
+            openDB.onsuccess = function () {
+                console.log("save on success")
+                var db = {};
+                db.result = openDB.result;
+                db.tx = db.result.transaction(storeName, "readwrite");
+                db.store = db.tx.objectStore(storeName);
+                db.store.put(value);
+                resolve()
+            }
+        });
     }
+
+    async clear() {
+        const dbName = this.dbName
+        const storeName = this.storeName
+
+        return new Promise(function (resolve) {
+            let openDB = indexedDB.open(dbName, 1);
+
+            openDB.onupgradeneeded = function () {
+                var db = {}
+                db.result = openDB.result;
+                db.store = db.result.createObjectStore(storeName, {keyPath: "id"});
+            };
+
+            openDB.onsuccess = function () {
+                let db = {};
+                db.result = openDB.result;
+                db.tx = db.result.transaction(storeName, "readwrite");
+                db.store = db.tx.objectStore(storeName);
+                let request = db.store.clear();
+                request.onsuccess = function () {
+                    resolve()
+                };
+            }
+        });
+    }
+
 
 }

--- a/cmd/user-agent/src/pages/chapi/wallet/didmgmt/didManager.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/didmgmt/didManager.js
@@ -105,7 +105,7 @@ export class DIDManager extends KeyValueStore {
         return this.get(did)
     }
 
-    storeDIDMetadata(did, metadata) {
+    async storeDIDMetadata(did, metadata) {
         return this.store(did, metadata)
     }
 

--- a/cmd/user-agent/src/pages/chapi/wallet/index.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/index.js
@@ -11,3 +11,4 @@ export {WalletGet} from './get/getCredentials.js';
 export {WalletGetByQuery} from './get/getCredentialsByQuery.js';
 export {DIDAuth} from './get/didAuth.js';
 export {RegisterWallet} from './register/register.js';
+export {WalletManager} from './register/walletManager.js';

--- a/cmd/user-agent/src/pages/chapi/wallet/register/register.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/register/register.js
@@ -4,31 +4,72 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
+import {WalletManager} from './walletManager'
+
+var uuid = require('uuid/v4')
+
+const keyType = "Ed25519"
+const signType = "Ed25519Signature2018"
+var allowedTypes = ['VerifiablePresentation', 'VerifiableCredential']
+
 /**
- * RegisterWallet registers webcredential handler
+ * RegisterWallet registers webcredential handler and manages wallet metadat in underlying db
  * @param polyfill and web credential handler
  * @class
  */
-export class RegisterWallet {
-    constructor(polyfill, wcredHandler) {
+export class RegisterWallet extends WalletManager {
+    constructor(polyfill, wcredHandler, didManager) {
+        super()
+
         this.polyfill = polyfill
         this.wcredHandler = wcredHandler
+        this.didManager = didManager
     }
 
     async register(user) {
+        // create DID
+        let did = await this.didManager.createDID(keyType, signType)
+
+        // save DID
+        await this.didManager.saveDID(`${user}_${uuid()}`, did)
+
+        console.log(`created DID ${did.id} successfully for user ${this.username}`)
+
         try {
             await this.polyfill.loadOnce();
-        } catch(e) {
-           console.error('Error in loadOnce:', e);
-           throw "failed to register wallet, please try again later"
+        } catch (e) {
+            console.error('Error in loadOnce:', e);
+            throw "failed to register wallet, please try again later"
         }
 
-        const registration = await  this.wcredHandler.installHandler({url: '/worker.html'})
+        const registration = await this.wcredHandler.installHandler({url: '/worker.html'})
 
         await registration.credentialManager.hints.set(
             'edge', {
                 name: user,
-                enabledTypes: ['VerifiablePresentation', 'VerifiableCredential']
+                enabledTypes: allowedTypes
             });
+
+        // clear any existing date
+        await this.clear()
+
+        // save wallet metadata
+        await this.storeWalletMetadata(user, {
+            signatureType: signType,
+            did: did.id
+        })
+    }
+
+    async unregister() {
+        await this.clear()
+
+        try {
+            await this.polyfill.loadOnce();
+        } catch (e) {
+            console.error('Error in loadOnce:', e);
+            return
+        }
+
+        await this.wcredHandler.uninstallHandler({url: '/worker.html'})
     }
 }

--- a/cmd/user-agent/src/pages/chapi/wallet/register/walletManager.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/register/walletManager.js
@@ -1,0 +1,42 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import {KeyValueStore} from '../common/keyValStore.js'
+
+const dbName = "wallet-metadata"
+const storeName = "metadata"
+
+/**
+ * WalletManager manages create/store/query features for wallet metadata
+ * @class
+ */
+export class WalletManager extends KeyValueStore {
+    constructor() {
+        super(dbName, storeName)
+    }
+
+    async getAllWalletMetadata() {
+        return this.getAll()
+    }
+
+    async getWalletMetadata(user) {
+        return this.get(user)
+    }
+
+    async storeWalletMetadata(user, metadata) {
+        return this.store(user, metadata)
+    }
+
+    async getRegisteredUser() {
+        let result = await this.getAllWalletMetadata()
+        if (!result || result.length == 0) {
+            return
+        }
+
+        return result[0]
+    }
+
+}


### PR DESCRIPTION
- webwallet login will register wallet and assign a DID for each login
- webwallet logout will unregister and removed wallet user entry from db
- webwallet get by credential query will use wallet user did for signing
presentation
- For now, DID auth will still continue to use created DIDs from DID
management.

- Closes #187

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>