### PR TITLE
feat: webwallet manifest VC and presentation location

### DIFF
--- a/cmd/user-agent/src/pages/WebWallet.vue
+++ b/cmd/user-agent/src/pages/WebWallet.vue
@@ -394,8 +394,8 @@ SPDX-License-Identifier: Apache-2.0
                 }
 
 
-                let invitation = JSON.parse(this.interopData)
-                if (invitation['@type'] != 'https://didcomm.org/didexchange/1.0/invitation') {
+                let request = JSON.parse(this.interopData)
+                if (!request.invitation) {
                     this.errors.push("Invalid invitation, expecting did comm invitation")
                     return
                 }
@@ -405,7 +405,8 @@ SPDX-License-Identifier: Apache-2.0
                     web: {
                         VerifiablePresentation: {
                             query: {type: "DIDConnect"},
-                            invitation: JSON.parse(this.interopData),
+                            invitation: request.invitation,
+                            manifest: request.manifest,
                             challenge: "54f3da1a-d1af-4c25-b1a6-90315dda62fc",
                             domain: "issuer.interop.example.com"
                         }

--- a/cmd/user-agent/src/pages/chapi/wallet/common/util.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/common/util.js
@@ -7,12 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 export const toLower = text => text.toString().toLowerCase()
 
 export const getCredentialType = (types) => {
-    const result = types.filter(type => !isCredentialType(type))
-    if (result.length > 0) {
-        return result[0]
-    }
-
-    return ""
+    let result = types.filter(type => !isCredentialType(type))
+    return result.length > 0 ? result[0] : ""
 }
 
 export const isCredentialType = (type) => isVCType(type) || isVPType(type)

--- a/test/user-agent/test/presentationDefQuery/testdata.js
+++ b/test/user-agent/test/presentationDefQuery/testdata.js
@@ -300,3 +300,25 @@ export const degreeCertificare = {
     }
 }
 
+export const pdCardManifestVC = {
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://trustbloc.github.io/context/vc/issuer-manifest-credential-v1.jsonld"
+    ],
+    "type": [
+        "VerifiableCredential",
+        "IssuerManifestCredential"
+    ],
+    "name": "Example Issuer Manifest Credential",
+    "description": "List of verifiable credentials provided by example issuer",
+    "id": "http://example.gov/credentials/ff98f978-588f-4eb0-b17b-60c18e1dac2c",
+    "issuanceDate": "2020-03-16T22:37:26.544Z",
+    "issuer": "did:factom:5d0dd58757119dd437c70d92b44fbf86627ee275f0f2146c3d99e441da342d9f",
+    "credentialSubject": {
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "contexts" : [
+            "https://w3id.org/citizenship/v3",
+            "https://w3id.org/citizenship/v4"
+        ]
+    }
+}


### PR DESCRIPTION
- added feature of fallback search to manifest VC, when a descriptor
fails to find matches it will go through manifest VCs
- did connect request can have manifest VCs along with invitation
- TODO: result VC to have details enough to establish did comm between
RP & Issuer for fetching VCs dynamically
- Closes #211

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>