### PR TITLE
feat: Added dev mode

### DIFF
--- a/cmd/user-agent/src/components/SidebarPlugin/SideBar.vue
+++ b/cmd/user-agent/src/components/SidebarPlugin/SideBar.vue
@@ -39,6 +39,12 @@ SPDX-License-Identifier: Apache-2.0
           </sidebar-link>
         </slot>
       </md-list>
+      <div class="dev-mode">
+        <div>
+          <md-checkbox v-model="devMode">Developer Mode
+          </md-checkbox>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -84,6 +90,18 @@ export default {
       autoClose: this.autoClose
     };
   },
+  data: () => ({
+    devMode: false,
+  }),
+  mounted() {
+    this.devMode = localStorage.devMode === "true";
+  },
+  watch: {
+    devMode(val) {
+      localStorage.devMode = val;
+      this.$root.$emit('dev_mode', val);
+    },
+  },
   computed: {
     sidebarStyle() {
       return {
@@ -98,5 +116,17 @@ export default {
   .nav-mobile-menu {
     display: none;
   }
+}
+</style>
+
+<style scoped>
+.dev-mode {
+  position: absolute;
+  bottom: 0;
+  width: 100%
+}
+
+.dev-mode > div {
+  text-align: center;
 }
 </style>

--- a/cmd/user-agent/src/main.js
+++ b/cmd/user-agent/src/main.js
@@ -127,6 +127,14 @@ Vue.use(MaterialDashboard);
 
 new Vue({
     el: "#app",
+    data: () => ({
+        devMode: false,
+    }),
+    mounted: function () {
+        this.$root.$on('dev_mode', function (val) {
+            this.devMode= val
+        })
+    },
     render: h => h(App),
     router
 });

--- a/cmd/user-agent/src/pages/Layout/DashboardLayout.vue
+++ b/cmd/user-agent/src/pages/Layout/DashboardLayout.vue
@@ -23,15 +23,15 @@ SPDX-License-Identifier: Apache-2.0
         <md-icon>flip_to_back</md-icon>
         <p>DID Management</p>
       </sidebar-link>
-      <sidebar-link to="/connections">
+      <sidebar-link v-if="$root.devMode" to="/connections">
         <md-icon>compare_arrows</md-icon>
         <p>Connections</p>
       </sidebar-link>
-      <sidebar-link to="/issue-credential">
+      <sidebar-link v-if="$root.devMode" to="/issue-credential">
         <md-icon>note</md-icon>
         <p>Issue Credential</p>
       </sidebar-link>
-      <sidebar-link to="/present-proof">
+      <sidebar-link v-if="$root.devMode" to="/present-proof">
         <md-icon>security</md-icon>
         <p>Present Proof</p>
       </sidebar-link>


### PR DESCRIPTION
Added `dev mode` support. Now, we have a button to switch between modes. Switching between modes triggers an event. So, we can listen to events and draw stuff according to the chosen mode.

Screens:
![Screen Shot 2020-08-04 at 6 08 48 PM](https://user-images.githubusercontent.com/12339578/89310788-df125c80-d67d-11ea-8072-a10a95e07e45.png) ![Screen Shot 2020-08-04 at 6 08 37 PM](https://user-images.githubusercontent.com/12339578/89310792-e0438980-d67d-11ea-8d87-1b4b315e9aeb.png)

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>