### PR TITLE
feat: Plaintext DID storage in SDS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ yarn-debug.log*
 yarn-error.log*
 
 cmd/user-agent/web/dist
+cmd/user-agent/dist
 test/bdd/fixtures/keys/tls
 test/bdd/fixtures/agent-wasm/config/
 test/bdd/fixtures/discovery-server/config

--- a/cmd/http-server/startcmd/start.go
+++ b/cmd/http-server/startcmd/start.go
@@ -95,6 +95,12 @@ const (
 		" Alternatively, this can be set with the following environment variable: " +
 		agentHTTPResolverEnvKey
 
+	// TODO Derive the SDS URL from the hub-auth bootstrap data #271
+	sdsURLFlagName      = "sds-url"
+	sdsURLFlagShorthand = "s"
+	sdsURLFlagUsage     = "URL SDS instance is running on."
+	sdsURLEnvKey        = "HTTP_SERVER_SDS_URL"
+
 	// aries opts path
 	ariesStartupOptsPath = "/aries/jsopts"
 	indexHTLMPath        = "/index.html"
@@ -132,6 +138,9 @@ type trustblocAgentJSOpts struct {
 	BlocDomain        string `json:"blocDomain,omitempty"`
 	WalletMediatorURL string `json:"walletMediatorURL,omitempty"`
 	LogLevel          string `json:"log-level,omitempty"`
+	// TODO get username from the actual registration process instead of a cmd line arg #266
+	AgentUsername string `json:"agentUsername,omitempty"`
+	SDSServerURL  string `json:"sdsServerURL,omitempty"`
 }
 
 // VueHandler return a http.Handler that supports Vue Router app with history mode
@@ -261,6 +270,7 @@ func createFlags(startCmd *cobra.Command) {
 	// trustbloc agent wallet mediator URL
 	startCmd.Flags().StringP(walletMediatorURLFlagName, walletMediatorURLFlagShorthand, "",
 		walletMediatorURLFlagUsage)
+	startCmd.Flags().StringP(sdsURLFlagName, sdsURLFlagShorthand, "", sdsURLFlagUsage)
 }
 
 func fetchAriesWASMAgentOpts(cmd *cobra.Command) (*ariesJSOpts, error) {
@@ -317,10 +327,25 @@ func fetchTrustBlocWASMAgentOpts(cmd *cobra.Command) (*trustblocAgentJSOpts, err
 		return nil, err
 	}
 
+	// This is used for storage of docs in SDS.
+	// TODO get username from the actual registration process instead of a cmd line arg #266
+	agentUsername, err := cmdutils.GetUserSetVarFromString(
+		cmd, agentDefaultLabelFlagName, agentDefaultLabelEnvKey, false)
+	if err != nil {
+		return nil, err
+	}
+
+	sdsServerURL, err := cmdutils.GetUserSetVarFromString(cmd, sdsURLFlagName, sdsURLEnvKey, false)
+	if err != nil {
+		return nil, err
+	}
+
 	return &trustblocAgentJSOpts{
 		BlocDomain:        blocDomain,
 		WalletMediatorURL: walletMediatorURL,
 		LogLevel:          logLevel,
+		AgentUsername:     agentUsername,
+		SDSServerURL:      sdsServerURL,
 	}, nil
 }
 

--- a/cmd/http-server/startcmd/start_test.go
+++ b/cmd/http-server/startcmd/start_test.go
@@ -155,6 +155,8 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + blocDomainFlagName, "domain",
 			"--" + agentAutoAcceptFlagName, "false",
 			"--" + agentHTTPResolverFlagName, "sidetree@http://localhost:8901",
+			"--" + agentDefaultLabelFlagName, "agent1",
+			"--" + sdsURLFlagName, "someURL",
 		}
 		startCmd.SetArgs(args)
 
@@ -173,7 +175,9 @@ func TestStartCmdValidArgs(t *testing.T) {
 		"--" + blocDomainFlagName, "domain",
 		"--" + walletMediatorURLFlagName, "http://localhost:8999",
 		"--" + agentAutoAcceptFlagName, "false",
-		"--" + agentHTTPResolverFlagName, "sidetree@http://localhost:8901"}
+		"--" + agentHTTPResolverFlagName, "sidetree@http://localhost:8901",
+		"--" + agentDefaultLabelFlagName, "agent1",
+		"--" + sdsURLFlagName, "someURL"}
 	startCmd.SetArgs(args)
 
 	err := startCmd.Execute()
@@ -194,6 +198,12 @@ func TestStartCmdValidArgsEnvVar(t *testing.T) {
 	require.NoError(t, err)
 
 	err = os.Setenv(blocDomainEnvKey, "domain")
+	require.NoError(t, err)
+
+	err = os.Setenv(agentDefaultLabelEnvKey, "agent1")
+	require.NoError(t, err)
+
+	err = os.Setenv(sdsURLEnvKey, "someURL")
 	require.NoError(t, err)
 
 	err = startCmd.Execute()

--- a/cmd/trustbloc-agent-js-worker/go.sum
+++ b/cmd/trustbloc-agent-js-worker/go.sum
@@ -204,8 +204,11 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4/go.mod h1:9PdLyPiZIiW3UopXyRnPYyjUXSpiQNHRLu8fOsR3o8M=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
+github.com/trustbloc/edv v0.1.4-0.20200709125604-431111de48f5 h1:/CSrp3U/nLNAdn6W7t4hii/EdPmGXX8RCRqHnnOum/w=
+github.com/trustbloc/edv v0.1.4-0.20200709125604-431111de48f5/go.mod h1:/XB21GAv8cJWDIbyIC+q4b4ePVU0FxAhqNwnxSIFt7k=
 github.com/trustbloc/sidetree-core-go v0.1.4-0.20200702215916-b02022f5ec37 h1:eXOLEJDXvu8ek0GkthyVNWGyE6/CnlsMeNOPSaX3IkM=
 github.com/trustbloc/sidetree-core-go v0.1.4-0.20200702215916-b02022f5ec37/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/trustbloc/trustbloc-did-method v0.1.4-0.20200709150904-54a502143328 h1:F1aoiy4rWThRe2OCzSNbDGHKJR5tQV6cBcnhgy+aXbo=

--- a/cmd/trustbloc-agent-js-worker/main.go
+++ b/cmd/trustbloc-agent-js-worker/main.go
@@ -57,8 +57,10 @@ type result struct {
 
 // trustblocAgentStartOpts contains opts for starting trustbloc agent
 type trustblocAgentStartOpts struct {
-	BlocDomain string `json:"blocDomain"`
-	LogLevel   string `json:"log-level"`
+	BlocDomain    string `json:"blocDomain"`
+	LogLevel      string `json:"log-level"`
+	AgentUsername string `json:"agentUsername"`
+	SDSServerURL  string `json:"sdsServerURL"`
 }
 
 // main registers the 'handleMsg' function in the JS context's global scope to receive commands.
@@ -182,7 +184,8 @@ func addTrustBlocAgentHandlers(pkgMap map[string]map[string]func(*command) *resu
 			return newErrResult(c.ID, err.Error())
 		}
 
-		commands, err := controller.GetCommandHandlers(controller.WithBlocDomain(cOpts.BlocDomain))
+		commands, err := controller.GetCommandHandlers(controller.WithBlocDomain(cOpts.BlocDomain),
+			controller.WithSDSServerURL(cOpts.SDSServerURL), controller.WithAgentUsername(cOpts.AgentUsername))
 		if err != nil {
 			return newErrResult(c.ID, err.Error())
 		}

--- a/cmd/trustbloc-agent-js-worker/src/trustblocagent.js
+++ b/cmd/trustbloc-agent-js-worker/src/trustblocagent.js
@@ -124,6 +124,9 @@ const TrustBlocAgent = function (opts) {
             createDID: async function (req) {
                 return invoke(aw, pending, this.pkgname, "CreateDID", req, "timeout while creating did")
             },
+            saveDID: async function (req) {
+                return invoke(aw, pending, this.pkgname, "SaveDID", req, "timeout while saving did")
+            },
         },
     }
 

--- a/cmd/user-agent/src/main.js
+++ b/cmd/user-agent/src/main.js
@@ -89,7 +89,9 @@ async function trustblocStartupOpts() {
         assetsPath: defaultTrustBlocStartupOpts['assetsPath'],
         blocDomain: ('blocDomain' in startupOpts) ? startupOpts['blocDomain'] : defaultTrustBlocStartupOpts['blocDomain'],
         walletMediatorURL: ('walletMediatorURL' in startupOpts) ? startupOpts['walletMediatorURL'] : defaultTrustBlocStartupOpts['walletMediatorURL'],
-        'log-level': ('log-level' in startupOpts) ? startupOpts['log-level'] : defaultTrustBlocStartupOpts['log-level']
+        'log-level': ('log-level' in startupOpts) ? startupOpts['log-level'] : defaultTrustBlocStartupOpts['log-level'],
+        agentUsername: startupOpts['agentUsername'],
+        sdsServerUrl: startupOpts['sdsServerURL']
     }
 }
 

--- a/cmd/user-agent/src/pages/DIDManagement.vue
+++ b/cmd/user-agent/src/pages/DIDManagement.vue
@@ -213,18 +213,20 @@ SPDX-License-Identifier: Apache-2.0
                     did = await this.didManager.createDID(this.selectType, this.signType)
                 } catch (e) {
                     this.loading = false;
-                    this.didDocTextArea = `failed to create did : ${e.toString()}`
+                    this.didDocTextArea = `failed to create did: ${e.toString()}`
+                    return;
                 }
 
                 this.didDocTextArea = JSON.stringify(did, undefined, 2);
 
                 // saving did
                 try {
-                     await this.didManager.saveDID(this.friendlyName, did)
+                     await this.didManager.saveDID(this.friendlyName, this.signType, did)
                 } catch (e) {
                     this.loading = false;
-                    this.didDocTextArea = `failed to save did : ${e.toString()}`
+                    this.didDocTextArea = `failed to save did: ${e.toString()}`
                     console.error("failed to save did", e)
+                    return;
                 }
 
                 // saving did metadata
@@ -281,7 +283,7 @@ SPDX-License-Identifier: Apache-2.0
 
                 // saving did
                 try {
-                    await this.didManager.saveDID(this.anyDIDFriendlyName, resp.did)
+                    await this.didManager.saveDID(this.anyDIDFriendlyName, this.selectSignKey, resp.did)
                 } catch (e) {
                     this.anyDidDocTextArea = `failed to save did : ${e.toString()}`
                     console.error("failed to save the did", e)

--- a/cmd/user-agent/src/pages/chapi/wallet/didmgmt/didManager.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/didmgmt/didManager.js
@@ -27,7 +27,7 @@ export class DIDManager extends KeyValueStore {
 
     async createDID(keyType, signType) {
         if (!this.aries || !this.trustblocAgent) {
-            console.error("aries and trustbloc agents are required to created DIDs")
+            console.error("aries and trustbloc agents are required to create DIDs")
             throw "operation not supported"
         }
 
@@ -84,17 +84,27 @@ export class DIDManager extends KeyValueStore {
         return did
     }
 
-    async saveDID(name, did){
-        if (!this.aries) {
-            console.error("aries agent required for saving DIDs")
+    async saveDID(name, signType, did){
+        if (!this.aries || !this.trustblocAgent) {
+            console.error("aries and trustbloc agents are required for saving DIDs")
             throw "operation not supported"
         }
 
+        // Save DID to local browser storage
         await this.aries.vdri.saveDID({
                 name: name,
                 did: did
             }
         )
+
+        const t = await new this.trustblocAgent.Framework(this.trustblocStartupOpts)
+
+        // Save DID to persistent storage
+        await t.didclient.saveDID({
+            name: name,
+            signType: signType,
+            did: did
+        })
     }
 
     async getAllDIDMetadata() {
@@ -108,5 +118,4 @@ export class DIDManager extends KeyValueStore {
     async storeDIDMetadata(did, metadata) {
         return this.store(did, metadata)
     }
-
 }

--- a/cmd/user-agent/src/pages/chapi/wallet/register/register.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/register/register.js
@@ -36,7 +36,7 @@ export class RegisterWallet extends WalletManager {
         let did = await this.didManager.createDID(keyType, signType)
 
         // save DID
-        await this.didManager.saveDID(`${user}_${uuid()}`, did)
+        await this.didManager.saveDID(`${user}_${uuid()}`, signType, did)
 
         console.log(`created DID ${did.id} successfully for user ${this.username}`)
 

--- a/cmd/user-agent/src/pages/chapi/wallet/register/walletManager.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/register/walletManager.js
@@ -21,7 +21,7 @@ export class WalletManager extends KeyValueStore {
     constructor() {
         super(`${dbName}-${metadataStore}`, metadataStore)
 
-        // TODO EDV will be used in future for these stores
+        // TODO SDS will be used in future for these stores #268
         this.manifestStore = new KeyValueStore(`${dbName}-${manifestStore}`, manifestStore)
         this.connectionStore = new KeyValueStore(`${dbName}-${connectionsStore}`, connectionsStore)
     }

--- a/docs/test/test.md
+++ b/docs/test/test.md
@@ -62,6 +62,10 @@ make user-agent-start
 - To access user agent wasm open [user home page](https://127.0.0.1:8091/dashboard).
 - To access second user agent wasm open [user home page](https://127.0.0.1:8071/dashboard).
 
+## Data Storage
+
+- The `make user-agent-start` command also starts up an [SDS instance](https://github.com/trustbloc/edv) with a CouchDB backend that's used for persistent data storage. If you want to examine the database for yourself while the agents are running, open the [CouchDB Fauxton Interface](http://127.0.0.1:5984/_utils). Note that the CouchDb instance started up by the `make user-agent-start` command will lose its data when the image is stopped.
+
 ## How to establish a did-connection between agents?
 
 1. Go to `Connections` page and register the router for both agents. Use `http://localhost:10093` as a router URL.

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,11 @@ module github.com/trustbloc/edge-agent
 go 1.13
 
 require (
+	github.com/btcsuite/btcutil v1.0.1
+	github.com/gorilla/mux v1.7.4
 	github.com/hyperledger/aries-framework-go v0.1.4-0.20200521101441-dcc599e23d09
 	github.com/stretchr/testify v1.5.1
 	github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6
+	github.com/trustbloc/edv v0.1.4-0.20200709125604-431111de48f5
 	github.com/trustbloc/trustbloc-did-method v0.1.4-0.20200709150904-54a502143328
 )

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,11 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4/go.mod h1:9PdLyPiZIiW3UopXyRnPYyjUXSpiQNHRLu8fOsR3o8M=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
+github.com/trustbloc/edv v0.1.4-0.20200709125604-431111de48f5 h1:/CSrp3U/nLNAdn6W7t4hii/EdPmGXX8RCRqHnnOum/w=
+github.com/trustbloc/edv v0.1.4-0.20200709125604-431111de48f5/go.mod h1:/XB21GAv8cJWDIbyIC+q4b4ePVU0FxAhqNwnxSIFt7k=
 github.com/trustbloc/sidetree-core-go v0.1.4-0.20200702215916-b02022f5ec37 h1:eXOLEJDXvu8ek0GkthyVNWGyE6/CnlsMeNOPSaX3IkM=
 github.com/trustbloc/sidetree-core-go v0.1.4-0.20200702215916-b02022f5ec37/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/trustbloc/trustbloc-did-method v0.1.4-0.20200709150904-54a502143328 h1:F1aoiy4rWThRe2OCzSNbDGHKJR5tQV6cBcnhgy+aXbo=

--- a/pkg/controller/command/sdscomm/sdscomm.go
+++ b/pkg/controller/command/sdscomm/sdscomm.go
@@ -1,0 +1,122 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sdscomm
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/trustbloc/edge-core/pkg/log"
+	sdsclient "github.com/trustbloc/edv/pkg/client"
+	"github.com/trustbloc/edv/pkg/restapi/messages"
+	"github.com/trustbloc/edv/pkg/restapi/models"
+)
+
+const sdsVaultIDLen = 16
+
+var logger = log.New("edge-agent-sdscomm")
+
+type SDSComm struct {
+	sdsServerURL  string
+	agentUsername string
+	sdsClient     *sdsclient.Client
+}
+
+type DIDDocData struct {
+	DID      json.RawMessage `json:"did,omitempty"`
+	SignType string          `json:"signType,omitempty"`
+	Name     string          `json:"name,omitempty"`
+}
+
+func New(sdsServerURL, agentUsername string) *SDSComm {
+	return &SDSComm{
+		sdsServerURL:  sdsServerURL,
+		agentUsername: agentUsername,
+		sdsClient:     sdsclient.New(sdsServerURL),
+	}
+}
+
+// CreateDIDVault creates the user's DID vault if it doesn't exist.
+func (e *SDSComm) CreateDIDVault() error {
+	didVaultID := e.GetDIDVaultID()
+
+	_, err := e.sdsClient.CreateDataVault(&models.DataVaultConfiguration{ReferenceID: didVaultID})
+	if err != nil {
+		if !strings.Contains(err.Error(), messages.ErrDuplicateVault.Error()) {
+			return err
+		}
+
+		logger.Debugf("%s vault already exists. Skipping vault creation.", didVaultID)
+	}
+
+	return nil
+}
+
+func (e *SDSComm) StoreDIDDocument(didData *DIDDocData) error {
+	structuredDoc := models.StructuredDocument{
+		ID: didData.Name,
+	}
+
+	structuredDoc.Content = make(map[string]interface{})
+
+	structuredDoc.Content["didDoc"] = didData.DID
+	structuredDoc.Content["signType"] = didData.SignType
+
+	encryptedDocID, err := generateSDSCompatibleID()
+	if err != nil {
+		return fmt.Errorf("failed to generate encrypted doc ID: %w", err)
+	}
+
+	indexedAttribute := models.IndexedAttribute{
+		Name:   "FriendlyName",
+		Value:  didData.Name, //TODO Don't leak friendly name to SDS #265
+		Unique: true,
+	}
+
+	indexedAttributeCollection := models.IndexedAttributeCollection{
+		IndexedAttributes: []models.IndexedAttribute{indexedAttribute},
+	}
+
+	indexedAttributeCollections := []models.IndexedAttributeCollection{indexedAttributeCollection}
+
+	structuredDocBytes, err := json.Marshal(structuredDoc)
+
+	// TODO encrypt data before storing in SDS #267
+	encryptedDoc := models.EncryptedDocument{
+		ID:                          encryptedDocID,
+		Sequence:                    0,
+		IndexedAttributeCollections: indexedAttributeCollections,
+		JWE:                         structuredDocBytes,
+	}
+
+	_, err = e.sdsClient.CreateDocument(e.GetDIDVaultID(), &encryptedDoc)
+	if err != nil {
+		return fmt.Errorf("failed to store DID document: %w", err)
+	}
+
+	return nil
+}
+
+// TODO don't leak username to SDS: #265
+func (e *SDSComm) GetDIDVaultID() string {
+	return e.agentUsername + "_dids"
+}
+
+func generateSDSCompatibleID() (string, error) {
+	randomBytes := make([]byte, sdsVaultIDLen)
+
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return "", err
+	}
+
+	base58EncodedUUID := base58.Encode(randomBytes)
+
+	return base58EncodedUUID, nil
+}

--- a/pkg/controller/command/sdscomm/sdscomm_test.go
+++ b/pkg/controller/command/sdscomm/sdscomm_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sdscomm
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/trustbloc/edv/pkg/restapi/messages"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edv/pkg/edvprovider/memedvprovider"
+	"github.com/trustbloc/edv/pkg/restapi"
+)
+
+func TestSDSComm_CreateDIDVault(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		sdsSrv := newTestEDVServer(t)
+		defer sdsSrv.Close()
+
+		sdsComm := New(fmt.Sprintf("%s/encrypted-data-vaults", sdsSrv.URL), "James")
+
+		err := sdsComm.CreateDIDVault()
+		require.NoError(t, err)
+	})
+	t.Run("SDS server unreachable (unsupported protocol scheme provided)", func(t *testing.T) {
+		sdsComm := New("BadURL", "James")
+
+		err := sdsComm.CreateDIDVault()
+		require.Contains(t, err.Error(), "unsupported protocol scheme")
+	})
+}
+
+func TestSDSComm_StoreDIDDocument(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		sdsSrv := newTestEDVServer(t)
+		defer sdsSrv.Close()
+
+		sdsComm := New(fmt.Sprintf("%s/encrypted-data-vaults", sdsSrv.URL), "James")
+
+		err := sdsComm.CreateDIDVault()
+		require.NoError(t, err)
+
+		sampleDIDDocData := DIDDocData{}
+
+		err = sdsComm.StoreDIDDocument(&sampleDIDDocData)
+		require.NoError(t, err)
+	})
+	t.Run("Fail to store - vault not found", func(t *testing.T) {
+		sdsSrv := newTestEDVServer(t)
+		defer sdsSrv.Close()
+
+		sdsComm := New(fmt.Sprintf("%s/encrypted-data-vaults", sdsSrv.URL), "James")
+
+		sampleDIDDocData := DIDDocData{}
+
+		err := sdsComm.StoreDIDDocument(&sampleDIDDocData)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), messages.ErrVaultNotFound.Error())
+	})
+}
+
+func newTestEDVServer(t *testing.T) *httptest.Server {
+	edvService, err := restapi.New(memedvprovider.NewProvider())
+	require.NoError(t, err)
+
+	handlers := edvService.GetOperations()
+	router := mux.NewRouter()
+	router.UseEncodedPath()
+
+	for _, handler := range handlers {
+		router.HandleFunc(handler.Path(), handler.Handle()).Methods(handler.Method())
+	}
+
+	return httptest.NewServer(router)
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,12 +7,18 @@ SPDX-License-Identifier: Apache-2.0
 package controller
 
 import (
+	"github.com/trustbloc/edge-core/pkg/log"
+
 	"github.com/trustbloc/edge-agent/pkg/controller/command"
 	didclientcmd "github.com/trustbloc/edge-agent/pkg/controller/command/didclient"
 )
 
+var logger = log.New("edge-agent-didclient-controller")
+
 type allOpts struct {
-	blocDomain string
+	blocDomain    string
+	agentUsername string // TODO get username from the actual registration process instead of a cmd line arg #266
+	sdsServerURL  string
 }
 
 // Opt represents a controller option.
@@ -25,6 +31,21 @@ func WithBlocDomain(blocDomain string) Opt {
 	}
 }
 
+// TODO get username from the actual registration process instead of a cmd line arg #266
+// WithAgentUsername is an option allowing for a username to be set.
+func WithAgentUsername(agentUsername string) Opt {
+	return func(opts *allOpts) {
+		opts.agentUsername = agentUsername
+	}
+}
+
+// WithSDSServerURL is an option allowing for the SDS server URL to be set.
+func WithSDSServerURL(sdsServerURL string) Opt {
+	return func(opts *allOpts) {
+		opts.sdsServerURL = sdsServerURL
+	}
+}
+
 // GetCommandHandlers returns all command handlers provided by controller.
 func GetCommandHandlers(opts ...Opt) ([]command.Handler, error) {
 	cmdOpts := &allOpts{}
@@ -34,7 +55,7 @@ func GetCommandHandlers(opts ...Opt) ([]command.Handler, error) {
 	}
 
 	// did client command operation
-	didClientCmd := didclientcmd.New(cmdOpts.blocDomain)
+	didClientCmd := didclientcmd.New(cmdOpts.blocDomain, cmdOpts.sdsServerURL, cmdOpts.agentUsername)
 
 	var allHandlers []command.Handler
 	allHandlers = append(allHandlers, didClientCmd.GetHandlers()...)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -13,7 +13,8 @@ import (
 
 func TestGetCommandHandlers(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		controller, err := GetCommandHandlers(WithBlocDomain("domain"))
+		controller, err := GetCommandHandlers(WithBlocDomain("domain"),
+			WithSDSServerURL("SomeURL"), WithAgentUsername("agent1"))
 		require.NoError(t, err)
 		require.NotNil(t, controller)
 	})

--- a/test/bdd/fixtures/agent-wasm/.env
+++ b/test/bdd/fixtures/agent-wasm/.env
@@ -44,3 +44,18 @@ BLOC_DID_METHOD_IMAGE_TAG=0.1.4-snapshot-54a5021
 
 HTTP_RESOLVER=trustbloc@http://localhost:9080/1.0/identifiers,v1@http://localhost:9080/1.0/identifiers,elem@http://localhost:9080/1.0/identifiers,sov@http://localhost:9080/1.0/identifiers,web@http://localhost:9080/1.0/identifiers,key@http://localhost:9080/1.0/identifiers
 WALLET_ROUTER_URL=http://localhost:10093
+
+COUCHDB_IMAGE=couchdb
+COUCHDB_IMAGE_TAG=2.3.1
+COUCHDB_PORT=5984
+
+SDS_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/edv-rest
+SDS_REST_IMAGE_TAG=0.1.4-snapshot-0c32078
+
+
+SDS_HOST=0.0.0.0
+SDS_PORT=8072
+SDS_DATABASE_TYPE=couchdb
+SDS_DATABASE_URL=couchdb.example.com:5984
+SDS_DATABASE_PREFIX=sds
+HTTP_SERVER_SDS_URL=https://localhost:8072/encrypted-data-vaults

--- a/test/bdd/fixtures/agent-wasm/docker-compose.yml
+++ b/test/bdd/fixtures/agent-wasm/docker-compose.yml
@@ -52,11 +52,14 @@ services:
       - ARIESD_DEFAULT_LABEL=user-agent
       - BLOC_DOMAIN=testnet.trustbloc.local
       - WALLET_MEDIATOR_URL=${WALLET_ROUTER_URL}
+      - HTTP_SERVER_SDS_URL=${HTTP_SERVER_SDS_URL}
     ports:
       - 8091:8091
     volumes:
       - ../keys/tls:/etc/tls
     command: start
+    depends_on:
+      - sds.example.com
 
   second.user.agent.example.com:
     container_name: second.user.agent.example.com
@@ -69,11 +72,39 @@ services:
       - ARIESD_DEFAULT_LABEL=second-user-agent
       - BLOC_DOMAIN=testnet.trustbloc.local
       - WALLET_MEDIATOR_URL=${WALLET_ROUTER_URL}
+      - HTTP_SERVER_SDS_URL=${HTTP_SERVER_SDS_URL}
     ports:
       - 8071:8071
     volumes:
       - ../keys/tls:/etc/tls
     command: start
+    depends_on:
+      - sds.example.com
+
+  couchdb.example.com:
+    container_name: couchdb.example.com
+    image: ${COUCHDB_IMAGE}:${COUCHDB_IMAGE_TAG}
+    ports:
+      - ${COUCHDB_PORT}:${COUCHDB_PORT}
+
+  sds.example.com:
+    container_name: sds.example.com
+    image: ${SDS_REST_IMAGE}:${SDS_REST_IMAGE_TAG}
+    environment:
+      - EDV_HOST_URL=${SDS_HOST}:${SDS_PORT}
+      - EDV_DATABASE_TYPE=${SDS_DATABASE_TYPE}
+      - EDV_DATABASE_URL=${SDS_DATABASE_URL}
+      - EDV_DATABASE_PREFIX=${SDS_DATABASE_PREFIX}
+      - EDV_LOG_LEVEL=debug
+      - EDV_TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
+      - EDV_TLS_KEY_FILE=/etc/tls/ec-key.pem
+    ports:
+      - ${SDS_PORT}:${SDS_PORT}
+    volumes:
+      - ../keys/tls:/etc/tls
+    command: start
+    depends_on:
+      - couchdb.example.com
 
   sidetree:
     container_name: sidetree-mock

--- a/test/user-agent/test/common.js
+++ b/test/user-agent/test/common.js
@@ -64,7 +64,10 @@ const ariesStartupOpts = {
 export const trustBlocStartupOpts = {
     assetsPath: '/base/public/trustbloc-agent/assets',
     blocDomain: 'testnet.trustbloc.local',
-    walletMediatorURL: 'http://localhost:10093'
+    walletMediatorURL: 'http://localhost:10093',
+    'log-level': 'debug',
+    sdsServerURL: 'https://localhost:8072/encrypted-data-vaults',
+    agentUsername: `user-agent`
 }
 
 export async function loadAries(name) {


### PR DESCRIPTION
closes #245, closes #269

- The "make user-agent-start" target now starts up an SDS and CouchDB instance
- DIDs are now stored in SDS (in plaintext) in addition to local browser storage

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>