### PR TITLE
feat: Newer aries snapshot (label instead of did id)

### DIFF
--- a/cmd/user-agent/package.json
+++ b/cmd/user-agent/package.json
@@ -9,7 +9,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@trustbloc-cicd/aries-framework-go": "0.1.4-snapshot-9add719",
+    "@trustbloc-cicd/aries-framework-go": "0.1.4-snapshot-0e1dd13",
     "@trustbloc/trustbloc-agent": "file:../trustbloc-agent-js-worker",
     "ajv": "^6.12.2",
     "core-js": "^3.4.3",

--- a/test/bdd/fixtures/agent-wasm/.env
+++ b/test/bdd/fixtures/agent-wasm/.env
@@ -12,7 +12,7 @@
 # Agent configurations
 USER_WASM_IMAGE=docker.pkg.github.com/trustbloc/edge-agent/user-agent-wasm
 AGENT_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/aries-framework-go/agent-rest
-AGENT_REST_IMAGE_TAG=amd64-0.1.4-snapshot-9add719
+AGENT_REST_IMAGE_TAG=amd64-0.1.4-snapshot-0e1dd13
 
 # Credential mediator configurations
 CREDENTIAL_MEDIATOR_IMAGE=docker.pkg.github.com/trustbloc/edge-agent/credential-mediator

--- a/test/user-agent/package.json
+++ b/test/user-agent/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "tests for user-agent vue components",
   "dependencies": {
-    "@trustbloc-cicd/aries-framework-go": "0.1.4-snapshot-9add719",
+    "@trustbloc-cicd/aries-framework-go": "0.1.4-snapshot-0e1dd13",
     "@trustbloc/trustbloc-agent": "file:../../cmd/trustbloc-agent-js-worker",
     "@trustbloc/user-agent": "file:../../cmd/user-agent",
     "jsonpath": "^1.0.2",


### PR DESCRIPTION
Now, when the user accepts the request, a friendly name will be displayed instead of did id.

<img width="518" alt="Screen Shot 2020-08-17 at 8 01 59 PM" src="https://user-images.githubusercontent.com/12339578/90423115-979bbf80-e0c4-11ea-8d1a-576fc3488b98.png">


Signed-off-by: Andrii Soluk <isoluchok@gmail.com>