### PR TITLE
feat: issuer manifest is matched if the credential schema uri is specified in a `const` filter

### DIFF
--- a/cmd/user-agent/src/pages/chapi/wallet/common/presentationExchange.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/common/presentationExchange.js
@@ -210,6 +210,12 @@ function matchManifest(manifest, descriptor) {
 
     let schemas = Array.isArray(descriptor.schema.uri) ? descriptor.schema.uri : [descriptor.schema.uri]
 
+    if (descriptor.constraints && descriptor.constraints.fields) {
+        descriptor.constraints.fields.filter(f => f.filter).filter(f => f.filter.const).forEach(f => {
+            schemas.push(f.filter.const)
+        })
+    }
+
     return manifest.credentialSubject.contexts.some(v => schemas.includes(v))
 }
 

--- a/test/user-agent/test/presentationDefQuery/testdata.js
+++ b/test/user-agent/test/presentationDefQuery/testdata.js
@@ -317,6 +317,55 @@ export const pdCardManifestVC = {
     }
 }
 
+export const driversLicenseVC = {
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://trustbloc.github.io/context/vc/examples/mdl-v1.jsonld"
+    ],
+    "type": [
+        "VerifiableCredential",
+        "mDL"
+    ],
+    "id": "http://example.gov/credentials/ff98f978-588f-4eb0-b17b-60c18e1dac2c",
+    "issuanceDate": "2020-03-16T22:37:26.544Z",
+    "issuer": {
+        "id": "did:gov:transport_ministry"
+    },
+    "credentialSubject": {
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "document_number": "123-456-789",
+        "given_name": "Jayden",
+        "family_name": "Doe"
+    },
+    "proof": {
+        "type": "Ed25519Signature2018",
+        "created": "2019-12-11T03:50:55Z",
+        "verificationMethod": "did:gov:transport_ministry#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+        "proofPurpose": "assertionMethod",
+        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..hckTjvJ8umMsgAdsgPfAYGKYh-4IqqvuGOX_kbNMwpkwyslFj_XKl06wgJDDMLkmnvHHEk74FDBUL_F_0mdeAA"
+    }
+}
+
+export const driversLicenseEvidenceManifestVC = {
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://trustbloc.github.io/context/vc/issuer-manifest-credential-v1.jsonld"
+    ],
+    "type": [
+        "VerifiableCredential",
+        "IssuerManifestCredential"
+    ],
+    "name": "Example Issuer Manifest Credential",
+    "description": "List of verifiable credentials provided by example issuer",
+    "id": "http://example.gov/credentials/ff98f978-588f-4eb0-b17b-60c18e1dac2c",
+    "issuanceDate": "2020-03-16T22:37:26.544Z",
+    "issuer": "did:factom:5d0dd58757119dd437c70d92b44fbf86627ee275f0f2146c3d99e441da342d9f",
+    "credentialSubject": {
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "contexts": ["https://trustbloc.github.io/context/vc/examples/driver-license-evidence-v1.jsonld"]
+    }
+}
+
 export const samplePresentationDefQuery1 = {
     submission_requirements: [
         {


### PR DESCRIPTION
This change is really more of a temporary (and cheap) solution to support [this](https://github.com/trustbloc/edge-adapter/pull/252) change in the RP edge-adapter.

I say this is *temporary* because I think a better solution would be to extend the [IssuerManifestCredential](https://github.com/trustbloc/context/blob/master/vc/issuer-manifest-credential-v1.jsonld) such that `contexts` is an array of VCs or VC-like objects against which the wallet and Issuer can evaluate the presentation-exchange criteria. This change would align better with [this existing TODO](https://github.com/trustbloc/edge-agent/blob/5b8834b8fe1ac848080f81b3c27ef46d22e65877/cmd/user-agent/src/pages/chapi/wallet/common/presentationExchange.js#L208).

Signed-off-by: George Aristy <george.aristy@securekey.com>