### PR TITLE
fix: Added default SDS URL and agent username TrustBloc agent opts

### DIFF
--- a/cmd/user-agent/src/main.js
+++ b/cmd/user-agent/src/main.js
@@ -69,6 +69,8 @@ let defaultTrustBlocStartupOpts = {
     'log-level': 'debug',
     walletMediatorURL: '',
     credentialMediatorURL: '',
+    agentUsername: 'user-agent',
+    sdsServerURL: 'https://localhost:8072/encrypted-data-vaults'
 }
 
 async function trustblocStartupOpts() {
@@ -93,8 +95,8 @@ async function trustblocStartupOpts() {
         walletMediatorURL: ('walletMediatorURL' in startupOpts) ? startupOpts['walletMediatorURL'] : defaultTrustBlocStartupOpts['walletMediatorURL'],
         credentialMediatorURL: credentialMediator(('credentialMediatorURL' in startupOpts) ? startupOpts['credentialMediatorURL'] : defaultTrustBlocStartupOpts['credentialMediatorURL']),
         'log-level': ('log-level' in startupOpts) ? startupOpts['log-level'] : defaultTrustBlocStartupOpts['log-level'],
-        agentUsername: startupOpts['agentUsername'],
-        sdsServerUrl: startupOpts['sdsServerURL']
+        agentUsername: ('agentUsername' in startupOpts) ? startupOpts['agentUsername'] : defaultTrustBlocStartupOpts['agentUsername'],
+        sdsServerURL: ('sdsServerURL' in startupOpts) ? startupOpts['sdsServerURL'] : defaultTrustBlocStartupOpts['sdsServerURL']
     }
 }
 

--- a/pkg/controller/command/didclient/command.go
+++ b/pkg/controller/command/didclient/command.go
@@ -43,6 +43,7 @@ const (
 	failDecodeDIDDocDataErrMsg = "failed to decode DID data"
 	failCreateDIDVaultErrMsg   = "failed to create DID vault"
 	failStoreDIDDocErrMsg      = "failed to store DID document"
+	failCreateSDSCommErrMsg    = "failure while preparing SDS communication"
 )
 
 type didBlocClient interface {
@@ -149,9 +150,13 @@ func (c *Command) SaveDID(_ io.Writer, req io.Reader) command.Error {
 }
 
 func (c *Command) saveDID(didDataToStore *sdscomm.DIDDocData) command.Error {
-	sdsComm := sdscomm.New(c.sdsServerURL, c.agentUsername)
+	sdsComm, err := sdscomm.New(c.sdsServerURL, c.agentUsername)
+	if err != nil {
+		return command.NewValidationError(InvalidRequestErrorCode,
+			fmt.Errorf("%s: %w", failCreateSDSCommErrMsg, err))
+	}
 
-	err := sdsComm.CreateDIDVault()
+	err = sdsComm.CreateDIDVault()
 	if err != nil {
 		logutil.LogInfo(logger, commandName, saveDIDCommandMethod,
 			fmt.Sprintf("%s: %s", failCreateDIDVaultErrMsg, err.Error()))

--- a/pkg/controller/command/didclient/command_test.go
+++ b/pkg/controller/command/didclient/command_test.go
@@ -129,7 +129,7 @@ func TestCommand_SaveDID(t *testing.T) {
 		require.Contains(t, cmdErr.Error(), failDecodeDIDDocDataErrMsg)
 	})
 	t.Run("Fail to save DID - SDS server unreachable", func(t *testing.T) {
-		cmd := New("", "BadURL", "")
+		cmd := New("", "BadURL", "agentUsername")
 
 		sampleDIDDocData := sdscomm.DIDDocData{}
 
@@ -138,6 +138,17 @@ func TestCommand_SaveDID(t *testing.T) {
 
 		cmdErr := cmd.SaveDID(nil, bytes.NewBuffer(didDocDataBytes))
 		require.Contains(t, cmdErr.Error(), failCreateDIDVaultErrMsg)
+	})
+	t.Run("Fail to save DID - failed to initialize sdscomm", func(t *testing.T) {
+		cmd := New("", "", "")
+
+		sampleDIDDocData := sdscomm.DIDDocData{}
+
+		didDocDataBytes, err := json.Marshal(sampleDIDDocData)
+		require.NoError(t, err)
+
+		cmdErr := cmd.SaveDID(nil, bytes.NewBuffer(didDocDataBytes))
+		require.Contains(t, cmdErr.Error(), failCreateSDSCommErrMsg)
 	})
 }
 

--- a/pkg/controller/command/sdscomm/sdscomm.go
+++ b/pkg/controller/command/sdscomm/sdscomm.go
@@ -8,6 +8,7 @@ package sdscomm
 import (
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -22,6 +23,9 @@ const sdsVaultIDLen = 16
 
 var logger = log.New("edge-agent-sdscomm")
 
+var errBlankSDSURL = errors.New("SDS server URL cannot be blank")
+var errBlankAgentUsername = errors.New("agent username cannot be blank")
+
 type SDSComm struct {
 	sdsServerURL  string
 	agentUsername string
@@ -34,12 +38,20 @@ type DIDDocData struct {
 	Name     string          `json:"name,omitempty"`
 }
 
-func New(sdsServerURL, agentUsername string) *SDSComm {
+func New(sdsServerURL, agentUsername string) (*SDSComm, error) {
+	if sdsServerURL == "" {
+		return nil, errBlankSDSURL
+	}
+
+	if agentUsername == "" {
+		return nil, errBlankAgentUsername
+	}
+
 	return &SDSComm{
 		sdsServerURL:  sdsServerURL,
 		agentUsername: agentUsername,
 		sdsClient:     sdsclient.New(sdsServerURL),
-	}
+	}, nil
 }
 
 // CreateDIDVault creates the user's DID vault if it doesn't exist.

--- a/pkg/controller/command/sdscomm/sdscomm_test.go
+++ b/pkg/controller/command/sdscomm/sdscomm_test.go
@@ -18,20 +18,40 @@ import (
 	"github.com/trustbloc/edv/pkg/restapi"
 )
 
+func TestNew(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		sdsComm, err := New("SDSUrl", "AgentUsername")
+		require.NoError(t, err)
+		require.NotNil(t, sdsComm)
+	})
+	t.Run("Failure: blank SDS URL", func(t *testing.T) {
+		sdsComm, err := New("", "AgentUsername")
+		require.EqualError(t, err, errBlankSDSURL.Error())
+		require.Nil(t, sdsComm)
+	})
+	t.Run("Failure: blank agent username URL", func(t *testing.T) {
+		sdsComm, err := New("SDSUrl", "")
+		require.EqualError(t, err, errBlankAgentUsername.Error())
+		require.Nil(t, sdsComm)
+	})
+}
+
 func TestSDSComm_CreateDIDVault(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		sdsSrv := newTestEDVServer(t)
 		defer sdsSrv.Close()
 
-		sdsComm := New(fmt.Sprintf("%s/encrypted-data-vaults", sdsSrv.URL), "James")
+		sdsComm, err := New(fmt.Sprintf("%s/encrypted-data-vaults", sdsSrv.URL), "James")
+		require.NoError(t, err)
 
-		err := sdsComm.CreateDIDVault()
+		err = sdsComm.CreateDIDVault()
 		require.NoError(t, err)
 	})
 	t.Run("SDS server unreachable (unsupported protocol scheme provided)", func(t *testing.T) {
-		sdsComm := New("BadURL", "James")
+		sdsComm, err := New("BadURL", "James")
+		require.NoError(t, err)
 
-		err := sdsComm.CreateDIDVault()
+		err = sdsComm.CreateDIDVault()
 		require.Contains(t, err.Error(), "unsupported protocol scheme")
 	})
 }
@@ -41,9 +61,10 @@ func TestSDSComm_StoreDIDDocument(t *testing.T) {
 		sdsSrv := newTestEDVServer(t)
 		defer sdsSrv.Close()
 
-		sdsComm := New(fmt.Sprintf("%s/encrypted-data-vaults", sdsSrv.URL), "James")
+		sdsComm, err := New(fmt.Sprintf("%s/encrypted-data-vaults", sdsSrv.URL), "James")
+		require.NoError(t, err)
 
-		err := sdsComm.CreateDIDVault()
+		err = sdsComm.CreateDIDVault()
 		require.NoError(t, err)
 
 		sampleDIDDocData := DIDDocData{}
@@ -55,11 +76,12 @@ func TestSDSComm_StoreDIDDocument(t *testing.T) {
 		sdsSrv := newTestEDVServer(t)
 		defer sdsSrv.Close()
 
-		sdsComm := New(fmt.Sprintf("%s/encrypted-data-vaults", sdsSrv.URL), "James")
+		sdsComm, err := New(fmt.Sprintf("%s/encrypted-data-vaults", sdsSrv.URL), "James")
+		require.NoError(t, err)
 
 		sampleDIDDocData := DIDDocData{}
 
-		err := sdsComm.StoreDIDDocument(&sampleDIDDocData)
+		err = sdsComm.StoreDIDDocument(&sampleDIDDocData)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), messages.ErrVaultNotFound.Error())
 	})


### PR DESCRIPTION
closes #296

- user-agent JavaScript code can now be run with "npm run serve" without SDS-related runtime errors.

- Added blank SDS URL check to sdscomm. This prevents an unintuitive error message from being produced.

- Added blank agent username check to sdscomm.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>