### PR TITLE
fix: Filters credential with an empty label

### DIFF
--- a/cmd/user-agent/src/store/modules/credentials.js
+++ b/cmd/user-agent/src/store/modules/credentials.js
@@ -35,7 +35,7 @@ export default {
             })
 
             // sets connections
-            commit('updateCredentials', res.result.filter(conn => conn.label !== ""))
+            commit('updateCredentials', res.result.filter(v => v.label))
 
             return res.result
         },


### PR DESCRIPTION
Filters associated credentials with null or missing labels.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>