### PR TITLE
feat: webwallet get user consent for sharing credentials over DIDComm

### DIFF
--- a/cmd/user-agent/src/pages/chapi/wallet/common/util.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/common/util.js
@@ -126,3 +126,6 @@ export async function waitForNotification(aries, topics, eventType, callback, ti
         }, timeout ? timeout : 10000)
     })
 }
+
+export const filterCredentialsByType = (creds, types, include) =>
+    creds.filter(c => include ? types.includes(getCredentialType(c.type)) : !types.includes(getCredentialType(c.type)))

--- a/cmd/user-agent/src/pages/chapi/wallet/get/didConn.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/get/didConn.js
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 import {WalletManager} from '../register/walletManager'
 import {WalletStore} from '../store/saveCredential'
 import {DIDExchange} from '../common/didExchange'
-import {getCredentialType} from "..";
+import {getCredentialType, filterCredentialsByType} from "..";
 
 const manifestCredType = "IssuerManifestCredential"
 //TODO actual credential type to be updated here
@@ -37,8 +37,7 @@ export class DIDConn {
     }
 
     getUserCredentials() {
-        return this.credentials ?
-            this.credentials.filter(c => ![manifestCredType, governanceCredType].includes(getCredentialType(c.type))) : []
+        return this.credentials ? filterCredentialsByType(this.credentials, [manifestCredType, governanceCredType]) : []
     }
 
     async connect() {


### PR DESCRIPTION
- in current implemnentation we show local and remote(didcomm)
credentials in same list in UI while getting consent from user.
- after this change, issuers who can issue credentials over didcomm will
be listed seprately and UI will show different messages for user
consent.

![image](https://user-images.githubusercontent.com/29631944/91522561-8cb50c00-e8c8-11ea-83b2-154a213e139a.png)
![image](https://user-images.githubusercontent.com/29631944/91522745-ff25ec00-e8c8-11ea-920d-40ddb4e9c49f.png)
![image](https://user-images.githubusercontent.com/29631944/91522705-e7e6fe80-e8c8-11ea-9750-28248b04c0ed.png)


- closes #317