### PR TITLE
feat: block access to CHAPI iframe for invalid session

### DIFF
--- a/cmd/user-agent/src/main.js
+++ b/cmd/user-agent/src/main.js
@@ -115,7 +115,17 @@ router.beforeEach((to, from, next) => {
             next()
         } else {
             next({
-                path: "login"
+                name: "login",
+                params: {redirect: to.name},
+            });
+        }
+    } else if (to.matched.some(record => record.meta.blockNoAuth)) {
+        if (store.dispatch('loadUser') && store.getters.getCurrentUser) {
+            next()
+        } else {
+            next({
+                name: "block-no-auth",
+                params: {login: "/login"},
             });
         }
     } else {

--- a/cmd/user-agent/src/pages/Layout/TopNavbar.vue
+++ b/cmd/user-agent/src/pages/Layout/TopNavbar.vue
@@ -7,11 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <md-toolbar md-elevation="0" class="md-transparent">
     <div class="md-toolbar-row">
-      <div class="md-toolbar-section-start">
-        <h3>
-          <span class="tim-note"></span>{{ $route.name }}
-        </h3>
-      </div>
       <div class="md-toolbar-section-end">
         <md-button
           class="md-just-icon md-simple md-toolbar-toggle"

--- a/cmd/user-agent/src/pages/chapi/BlockNoAuth.vue
+++ b/cmd/user-agent/src/pages/chapi/BlockNoAuth.vue
@@ -1,0 +1,33 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+<template>
+    <div style="margin: 5%">
+        <md-card md-with-hover>
+            <md-card-header data-background-color="red">
+                <div class="md-title">Access Denied</div>
+            </md-card-header>
+
+            <md-card-content style="font-size: 16px">
+                    You don't have authorization to access this page,
+                please login to your wallet <a v-bind:href="loginURL" target="_blank" style="font-weight: 600; font-style: italic">here</a> and try again.
+            </md-card-content>
+
+        </md-card>
+    </div>
+</template>
+
+<script>
+    export default {
+        data() {
+            return {
+                loginURL: this.$route.params['login'] ? this.$route.params['login'] : '/',
+            };
+        }
+    }
+
+</script>
+

--- a/cmd/user-agent/src/pages/chapi/DIDConnect.vue
+++ b/cmd/user-agent/src/pages/chapi/DIDConnect.vue
@@ -88,16 +88,9 @@ SPDX-License-Identifier: Apache-2.0
     export default {
         components: {Governance},
         beforeCreate: async function () {
-            // TODO move below validation to router and show agent login
-            let userState = this.$store.getters.getCurrentUser
-            if (!userState) {
-                //this can never happen, but still one extra layer of security
-                this.credentialWarning = 'Wallet is not registered'
-            }
-
             this.wallet = new DIDConn(await this.$arieslib,
                 await new this.$trustblocAgent.Framework(await this.$trustblocStartupOpts), this.$trustblocStartupOpts,
-                this.$parent.credentialEvent, userState.username)
+                this.$parent.credentialEvent, this.$store.getters.getCurrentUser.username)
             this.requestOrigin = this.$parent.credentialEvent.credentialRequestOrigin
             this.userCredentials = this.wallet.getUserCredentials()
             this.govnVC = this.wallet.getGovernanceCredential()

--- a/cmd/user-agent/src/pages/chapi/Login.vue
+++ b/cmd/user-agent/src/pages/chapi/Login.vue
@@ -50,9 +50,12 @@ SPDX-License-Identifier: Apache-2.0
 
     export default {
         beforeCreate: async function () {
+            let redirect = this.$route.params['redirect']
+            this.redirect = redirect ? {name: redirect} : '/'
+
             this.$store.dispatch('loadUser')
             if (this.$store.getters.getCurrentUser) {
-                this.$router.push("/dashboard");
+                this.$router.push(this.redirect);
                 return
             }
 
@@ -77,7 +80,6 @@ SPDX-License-Identifier: Apache-2.0
                 await this.loginUser(this.username)
                 let user = this.getCurrentUser()
 
-                console.log(`current user ${user.username}, logged in user ${this.username}`)
                 try {
                     if (!user || !user.metadata) {
                         // first time login, register this user
@@ -95,7 +97,7 @@ SPDX-License-Identifier: Apache-2.0
                 this.loading = false
             },
             handleSuccess() {
-                this.$router.push("/dashboard");
+                this.$router.push(this.redirect);
             },
             handleFailure(e) {
                 console.error(e)

--- a/cmd/user-agent/src/pages/chapi/PresentationDefQuery.vue
+++ b/cmd/user-agent/src/pages/chapi/PresentationDefQuery.vue
@@ -159,10 +159,6 @@ SPDX-License-Identifier: Apache-2.0
             await this.wallet.connect()
 
             this.requestOrigin = this.$parent.credentialEvent.credentialRequestOrigin
-            if (!this.$store.getters.getCurrentUser) {
-                //this can never happen, but still one extra layer of security
-                this.credentialWarning = 'Wallet is not registered'
-            }
 
             try {
                 this.presentation = await this.wallet.getPresentationSubmission()

--- a/cmd/user-agent/src/pages/chapi/wallet/register/register.js
+++ b/cmd/user-agent/src/pages/chapi/wallet/register/register.js
@@ -101,6 +101,6 @@ export class RegisterWallet extends WalletManager {
             return
         }
 
-        await this.wcredHandler.uninstallHandler({url: '/worker.html'})
+        await this.wcredHandler.uninstallHandler({url: '/worker'})
     }
 }

--- a/cmd/user-agent/src/router/index.js
+++ b/cmd/user-agent/src/router/index.js
@@ -21,85 +21,100 @@ import Relationships from "@/pages/Relationships.vue";
 import IssueCredential from "@/pages/IssueCredential.vue";
 import PresentProof from "@/pages/PresentProof.vue";
 import NotFound from '@/pages/PageNotFound'
+import BlockNoAuth from "@/pages/chapi/BlockNoAuth.vue";
+
 const routes = [
     {
         path: "/",
         component: DashboardLayout,
-        name: "dashboard",
+        // name: "dashboard",
         redirect: "dashboard",
         children: [
             {
                 path: "dashboard",
+                name: "dashboard",
                 component: Dashboard,
-                meta: { requiresAuth: true }
+                meta: {requiresAuth: true}
             },
             {
                 path: "login",
+                name: "login",
                 component: Login
             },
             {
                 path: "logout",
+                name: "logout",
                 component: Logout
             },
             {
                 path: "ViewVC",
-                name: "View Wallet",
+                name: "view-credential",
                 component: TableList
             },
             {
                 path: "MyVC",
-                name: "Generate Presentation",
+                name: "my-credential",
                 component: TablePresentation
             },
             {
                 path: "WebWallet",
-                name: "Web Wallet Demo",
+                name: "web-wallet",
                 component: WebWallet
             },
             {
                 path: "DIDManagement",
-                name: "DID Management",
+                name: "did-management",
                 component: DIDManagement
             },
             {
                 path: "connections",
-                name: "Connections",
+                name: "connections",
                 component: Connections
             },
             {
                 path: "relationships",
-                name: "Relationships",
+                name: "relationships",
                 component: Relationships
-            }, {
+            },
+            {
                 path: "issue-credential",
-                name: "Issue Credential",
+                name: "issue-credential",
                 component: IssueCredential
-            }, {
+            },
+            {
                 path: "present-proof",
-                name: "Present Proof",
+                name: "present-proof",
                 component: PresentProof
             }
         ]
     },
     {
         path: '*',
-        name: 'NotFound',
         component: NotFound
     },
     {
         path: "/StoreInWallet",
-        component: StoreInWallet
+        name: "chapi-store",
+        component: StoreInWallet,
+        meta: {blockNoAuth: true}
     },
     {
         path: "/GetFromWallet",
-        component: GetFromWallet
+        name: "chapi-get",
+        component: GetFromWallet,
+        meta: {blockNoAuth: true}
     },
     {
         path: "/worker",
+        name: "chapi-worker",
         component: WalletWorker
-    }
+    },
+    {
+        path: '/needauth',
+        name: "block-no-auth",
+        component: BlockNoAuth
+    },
 ];
-
 
 
 export default routes;


### PR DESCRIPTION
- securing CHAPI pages from acessing without auth
- login redirect made dynamic, can be applied to any page, not just
dashboard
- fixed logout issue where CHAPI polyfill wasn't getting unregistered.
- Closes #342
- Closes #343

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>