### PR TITLE
feat: user agent wallet demos to reuse webwallet user aries

### DIFF
--- a/cmd/user-agent/src/pages/Connections.vue
+++ b/cmd/user-agent/src/pages/Connections.vue
@@ -5,40 +5,46 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 <template>
-  <div class="content">
-    <div class="md-layout">
-      <div class="md-layout-item">
-        <div class="md-layout-item">
-          <mediator title="Mediator"/>
+    <div class="content">
+        <div class="md-layout">
+            <div class="md-layout-item">
+                <div class="md-layout-item">
+                    <mediator title="Mediator"/>
+                </div>
+                <div class="md-layout-item">
+                    <create-invitation/>
+                </div>
+                <div class="md-layout-item">
+                    <receive-invitation/>
+                </div>
+            </div>
+            <div class="md-layout-item">
+                <div class="md-layout-item">
+                    <connections :short="false" title="Connections" :count="pendingConnectionsCount"
+                                 :connections="allConnections"/>
+                </div>
+            </div>
         </div>
-        <div class="md-layout-item">
-          <create-invitation/>
-        </div>
-        <div class="md-layout-item">
-          <receive-invitation/>
-        </div>
-      </div>
-      <div class="md-layout-item">
-        <div class="md-layout-item">
-          <connections :short="false" title="Connections" :count="pendingConnectionsCount"
-                       :connections="allConnections"/>
-        </div>
-      </div>
     </div>
-  </div>
 </template>
 
 <script>
-import {Mediator, CreateInvitation, ReceiveInvitation, Connections} from "@/components";
-import {mapActions, mapGetters} from "vuex";
+    import {Connections, CreateInvitation, Mediator, ReceiveInvitation} from "@/components";
+    import {mapActions, mapGetters} from "vuex";
 
-export default {
-  components: {Mediator, CreateInvitation, ReceiveInvitation, Connections},
-  methods: mapActions(['queryConnections']),
-  mounted() {
-    // refreshes connections when component is mounted
-    this.queryConnections()
-  },
-  computed: mapGetters(['pendingConnectionsCount', 'allConnections']),
-}
+    export default {
+        components: {Mediator, CreateInvitation, ReceiveInvitation, Connections},
+        methods: {
+            ...mapActions(['queryConnections', 'onDidExchangeState', 'loadMediatorState']),
+            ...mapActions('aries', {addAriesNotifiers: 'addNotifier'})
+        },
+        mounted() {
+            this.addAriesNotifiers({callback: this.onDidExchangeState, topics: ["didexchange_states"]})
+            this.loadMediatorState()
+            // refreshes connections when component is mounted
+            this.queryConnections()
+        },
+        computed: mapGetters(['pendingConnectionsCount', 'allConnections']),
+
+    }
 </script>

--- a/cmd/user-agent/src/pages/DIDManagement.vue
+++ b/cmd/user-agent/src/pages/DIDManagement.vue
@@ -181,11 +181,10 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 
     import {DIDManager} from "./chapi/wallet";
-    import {mapGetters, mapActions} from 'vuex'
+    import {mapGetters} from 'vuex'
 
     export default {
         created: async function () {
-            await this.initAries()
             this.aries = this.getAriesInstance()
 
             const opts = await this.$trustblocStartupOpts
@@ -200,7 +199,6 @@ SPDX-License-Identifier: Apache-2.0
         },
         methods: {
             ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
-            ...mapActions('aries', {initAries: 'init'}),
             createDID: async function () {
                 this.errors.length = 0
                 if (this.friendlyName.length == 0) {

--- a/cmd/user-agent/src/pages/Dashboard.vue
+++ b/cmd/user-agent/src/pages/Dashboard.vue
@@ -40,7 +40,7 @@ SPDX-License-Identifier: Apache-2.0
     import {SimpleTable} from "@/components";
     import {getCredentialType} from "@/pages/chapi/wallet";
     import Logout from "@/pages/chapi/Logout.vue";
-    import {mapGetters, mapActions} from 'vuex'
+    import {mapGetters} from 'vuex'
 
     let vcData = [];
     async function fetchCredentials(aries) {
@@ -63,7 +63,6 @@ SPDX-License-Identifier: Apache-2.0
             SimpleTable,
         },
         created: async function () {
-            await this.initAries()
             // Load the Credentials
             this.aries = this.getAriesInstance()
             await this.getCredentials()
@@ -74,7 +73,6 @@ SPDX-License-Identifier: Apache-2.0
         methods: {
             ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
             ...mapGetters(['getCurrentUser']),
-            ...mapActions('aries', {initAries: 'init'}),
             getCredentials: async function () {
                 try {
                     let resp = await this.aries.verifiable.getCredentials()

--- a/cmd/user-agent/src/pages/IssueCredential.vue
+++ b/cmd/user-agent/src/pages/IssueCredential.vue
@@ -137,13 +137,20 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
+    import {mapGetters, mapActions} from 'vuex'
+
     export default {
-        beforeCreate: async function () {
-            window.$aries = await this.$arieslib
+        created: async function () {
+            this.addAriesNotifiers({callback:this.onIssueCredentialState, topics:["issue-credential_states"]})
+            this.aries = this.getAriesInstance()
+
             await this.queryConnections()
             await this.refreshActions()
         },
         methods: {
+            ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
+            ...mapActions('aries', {addAriesNotifiers: 'addNotifier'}),
+            ...mapActions(['onIssueCredentialState']),
             isOfferCredential: function (action) {
                 return action.Msg['@type'].endsWith('/offer-credential')
             },
@@ -168,7 +175,7 @@ SPDX-License-Identifier: Apache-2.0
                 }
 
                 try {
-                    await window.$aries.issuecredential.acceptCredential({
+                    await this.aries.issuecredential.acceptCredential({
                         piid: action.PIID,
                         names: this.issueCredentialNames.split(','),
                     })
@@ -182,7 +189,7 @@ SPDX-License-Identifier: Apache-2.0
             },
             declineCredential: async function (action) {
                 try {
-                    await window.$aries.issuecredential.declineCredential({
+                    await this.aries.issuecredential.declineCredential({
                         piid: action.PIID,
                     })
                 } catch (e) {
@@ -216,7 +223,7 @@ SPDX-License-Identifier: Apache-2.0
                 }
 
                 try {
-                    await window.$aries.issuecredential.acceptRequest({
+                    await this.aries.issuecredential.acceptRequest({
                         piid: action.PIID,
                         issue_credential: credential,
                     })
@@ -230,7 +237,7 @@ SPDX-License-Identifier: Apache-2.0
             },
             declineRequest: async function (action) {
                 try {
-                    await window.$aries.issuecredential.declineRequest({
+                    await this.aries.issuecredential.declineRequest({
                         piid: action.PIID,
                     })
                 } catch (e) {
@@ -242,12 +249,12 @@ SPDX-License-Identifier: Apache-2.0
                 await this.refreshActions()
             },
             refreshActions: async function () {
-                let res = await window.$aries.issuecredential.actions()
+                let res = await this.aries.issuecredential.actions()
                 this.actions = res.actions
             },
             declineOffer: async function (action) {
                 try {
-                    await window.$aries.issuecredential.declineOffer({
+                    await this.aries.issuecredential.declineOffer({
                         piid: action.PIID,
                     })
                 } catch (e) {
@@ -260,7 +267,7 @@ SPDX-License-Identifier: Apache-2.0
             },
             acceptOffer: async function (action) {
                 try {
-                    await window.$aries.issuecredential.acceptOffer({
+                    await this.aries.issuecredential.acceptOffer({
                         piid: action.PIID,
                     })
                 } catch (e) {
@@ -297,7 +304,7 @@ SPDX-License-Identifier: Apache-2.0
                 }
 
                 try {
-                    await window.$aries.issuecredential.sendOffer({
+                    await this.aries.issuecredential.sendOffer({
                         my_did: conn.MyDID,
                         their_did: conn.TheirDID,
                         offer_credential: offerCredential,
@@ -309,7 +316,7 @@ SPDX-License-Identifier: Apache-2.0
             },
             queryConnections: async function () {
                 try {
-                    let res = await window.$aries.didexchange.queryConnections()
+                    let res = await this.aries.didexchange.queryConnections()
                     if (res.results) {
                         this.connections = res.results.filter(function (conn) {
                             return conn.State === "completed";

--- a/cmd/user-agent/src/pages/PresentProof.vue
+++ b/cmd/user-agent/src/pages/PresentProof.vue
@@ -132,15 +132,21 @@
 </template>
 
 <script>
+    import {mapGetters, mapActions} from 'vuex'
+
     export default {
-        beforeCreate: async function () {
-            window.$aries = await this.$arieslib
+        created: async function () {
+            this.addAriesNotifiers({callback:this.onPresentProofState, topics:["present-proof_states"]})
+            this.aries = this.getAriesInstance()
             await this.queryConnections()
             await this.refreshActions()
         },
         methods: {
+            ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
+            ...mapActions('aries', {addAriesNotifiers: 'addNotifier'}),
+            ...mapActions(['onPresentProofState']),
             refreshActions: async function () {
-                let res = await window.$aries.presentproof.actions()
+                let res = await this.aries.presentproof.actions()
                 this.actions = res.actions
             },
             isRequestPresentation: function (action) {
@@ -163,7 +169,7 @@
                 }
 
                 try {
-                    await window.$aries.presentproof.acceptPresentation({
+                    await this.aries.presentproof.acceptPresentation({
                         piid: action.PIID,
                         names: this.presentationNames.split(','),
                     })
@@ -197,7 +203,7 @@
                 }
 
                 try {
-                    await window.$aries.presentproof.acceptRequestPresentation({
+                    await this.aries.presentproof.acceptRequestPresentation({
                         piid: action.PIID,
                         presentation: presentation,
                     })
@@ -212,7 +218,7 @@
             },
             declineRequestPresentation: async function (action) {
                 try {
-                    await window.$aries.presentproof.declineRequestPresentation({
+                    await this.aries.presentproof.declineRequestPresentation({
                         piid: action.PIID,
                     })
                 } catch (e) {
@@ -225,7 +231,7 @@
             },
             declinePresentation: async function (action) {
                 try {
-                    await window.$aries.presentproof.declinePresentation({
+                    await this.aries.presentproof.declinePresentation({
                         piid: action.PIID,
                     })
                 } catch (e) {
@@ -262,7 +268,7 @@
                 }
 
                 try {
-                    await window.$aries.presentproof.sendRequestPresentation({
+                    await this.aries.presentproof.sendRequestPresentation({
                         my_did: conn.MyDID,
                         their_did: conn.TheirDID,
                         request_presentation: requestPresentation,
@@ -274,7 +280,7 @@
             },
             queryConnections: async function () {
                 try {
-                    let res = await window.$aries.didexchange.queryConnections()
+                    let res = await this.aries.didexchange.queryConnections()
                     if (res.results) {
                         this.connections = res.results.filter(function (conn) {
                             return conn.State === "completed";

--- a/cmd/user-agent/src/pages/TablePresentation.vue
+++ b/cmd/user-agent/src/pages/TablePresentation.vue
@@ -88,15 +88,13 @@ SPDX-License-Identifier: Apache-2.0
 <script>
   import VueJsonPretty from 'vue-json-pretty';
   import {WalletStore} from "@/pages/chapi/wallet";
-  import {mapGetters, mapActions} from 'vuex'
+  import {mapGetters} from 'vuex'
 
   export default {
     components: {
       VueJsonPretty
     },
     created: async function () {
-      await this.initAries()
-
       const opts = await this.$trustblocStartupOpts
       this.wallet = new WalletStore(this.$store.getters.getCurrentUser.username, this.getAriesInstance(), this.$trustblocAgent, opts, null)
       await this.loadIssuers()
@@ -134,7 +132,6 @@ SPDX-License-Identifier: Apache-2.0
     },
     methods: {
       ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
-      ...mapActions('aries', {initAries: 'init'}),
       getDIDMetadata: function (id) {
         return new Promise(function(resolve) {
           var openDB = indexedDB.open("did-metadata", 1);

--- a/cmd/user-agent/src/pages/WebWallet.vue
+++ b/cmd/user-agent/src/pages/WebWallet.vue
@@ -86,7 +86,6 @@ SPDX-License-Identifier: Apache-2.0
 
     export default {
         beforeCreate: async function () {
-            this.aries = await this.$arieslib
             let opts = await this.$trustblocStartupOpts
             await this.$polyfill.loadOnce(opts.credentialMediatorURL)
         },

--- a/cmd/user-agent/src/pages/chapi/DIDAuth.vue
+++ b/cmd/user-agent/src/pages/chapi/DIDAuth.vue
@@ -70,12 +70,10 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 
     import {DIDAuth} from "./wallet"
-    import {mapGetters, mapActions} from 'vuex'
+    import {mapGetters} from 'vuex'
 
     export default {
         created: async function () {
-            await this.initAries()
-
             this.wallet = new DIDAuth(this.getAriesInstance(), this.$parent.credentialEvent)
             this.requestOrigin = this.$parent.credentialEvent.credentialRequestOrigin
 
@@ -94,7 +92,6 @@ SPDX-License-Identifier: Apache-2.0
         },
         methods: {
             ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
-            ...mapActions('aries', {initAries: 'init'}),
             loadIssuers: async function () {
                 try {
                     this.issuers = await this.wallet.getDIDRecords()

--- a/cmd/user-agent/src/pages/chapi/DIDConnect.vue
+++ b/cmd/user-agent/src/pages/chapi/DIDConnect.vue
@@ -84,12 +84,11 @@ SPDX-License-Identifier: Apache-2.0
 
     import {DIDConn} from "./wallet"
     import Governance from "./Governance.vue";
-    import {mapGetters, mapActions} from 'vuex'
+    import {mapGetters} from 'vuex'
 
     export default {
         components: {Governance},
         created: async function () {
-            await this.initAries()
             this.wallet = new DIDConn(this.getAriesInstance(),
                 await new this.$trustblocAgent.Framework(await this.$trustblocStartupOpts), this.$trustblocStartupOpts,
                 this.$parent.credentialEvent, this.$store.getters.getCurrentUser.username)
@@ -114,7 +113,6 @@ SPDX-License-Identifier: Apache-2.0
         },
         methods: {
             ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
-            ...mapActions('aries', {initAries: 'init'}),
             cancel: async function () {
                 this.wallet.cancel()
             },

--- a/cmd/user-agent/src/pages/chapi/GetCredentials.vue
+++ b/cmd/user-agent/src/pages/chapi/GetCredentials.vue
@@ -87,12 +87,10 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 
     import {searchByTypeAndHolder, WalletGet} from "./wallet"
-    import {mapGetters, mapActions} from 'vuex'
+    import {mapGetters} from 'vuex'
 
     export default {
         created: async function () {
-            await this.initAries()
-
             this.wallet = new WalletGet(this.getAriesInstance(), this.$parent.credentialEvent)
             this.search = this.wallet.search
             this.reason = this.wallet.reason
@@ -125,7 +123,6 @@ SPDX-License-Identifier: Apache-2.0
         },
         methods: {
             ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
-            ...mapActions('aries', {initAries: 'init'}),
             searchOnTable() {
                 this.searched = searchByTypeAndHolder(this.savedVCs, this.search, this.issuers[this.selectedIssuer].key)
             },

--- a/cmd/user-agent/src/pages/chapi/Logout.vue
+++ b/cmd/user-agent/src/pages/chapi/Logout.vue
@@ -17,15 +17,16 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 
     import {RegisterWallet} from "./wallet"
-    import {mapActions} from 'vuex'
+    import {mapActions, mapGetters} from 'vuex'
 
     export default {
-        beforeCreate: async function () {
-            this.registrar = new RegisterWallet(this.$polyfill, this.$webCredentialHandler, await this.$arieslib,
+        created: async function () {
+            this.registrar = new RegisterWallet(this.$polyfill, this.$webCredentialHandler, this.getAriesInstance(),
                 this.$trustblocAgent, await this.$trustblocStartupOpts)
         },
         methods: {
             ...mapActions({logoutUser: 'logout'}),
+            ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
             logout: async function () {
                 await this.registrar.uninstallHandlers()
                 await this.logoutUser()

--- a/cmd/user-agent/src/pages/chapi/PresentationDefQuery.vue
+++ b/cmd/user-agent/src/pages/chapi/PresentationDefQuery.vue
@@ -146,7 +146,7 @@ SPDX-License-Identifier: Apache-2.0
 
     import {filterCredentialsByType, getCredentialType, WalletGetByQuery} from "./wallet"
     import Governance from "./Governance.vue";
-    import {mapGetters, mapActions} from 'vuex'
+    import {mapGetters} from 'vuex'
 
     const warning = "No credentials found in your wallet for above information asked"
     const manifestCredType = 'IssuerManifestCredential'
@@ -154,8 +154,6 @@ SPDX-License-Identifier: Apache-2.0
     export default {
         components: {Governance},
         created: async function () {
-            await this.initAries()
-
             this.wallet = new WalletGetByQuery(this.getAriesInstance(), this.$parent.credentialEvent)
             await this.wallet.connect()
 
@@ -206,7 +204,6 @@ SPDX-License-Identifier: Apache-2.0
         methods: {
             ...mapGetters(['getCurrentUser']),
             ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
-            ...mapActions('aries', {initAries: 'init'}),
             createPresentation: async function () {
                 this.loading = true
                 await this.wallet.createAndSendPresentation(this.getCurrentUser().username, this.presentation, this.selectedVCs)

--- a/cmd/user-agent/src/pages/chapi/Store.vue
+++ b/cmd/user-agent/src/pages/chapi/Store.vue
@@ -82,12 +82,10 @@ SPDX-License-Identifier: Apache-2.0
 
 <script>
     import {isCredentialType, isVCType, getCredentialMetadata, WalletStore} from "./wallet"
-    import {mapGetters, mapActions} from 'vuex'
+    import {mapGetters} from 'vuex'
 
     export default {
         created: async function () {
-            await this.initAries()
-
             // Load the Credentials
             const credentialEvent = await this.$webCredentialHandler.receiveCredentialEvent();
             console.log("Credential event received :", credentialEvent.credential)
@@ -130,7 +128,6 @@ SPDX-License-Identifier: Apache-2.0
         methods: {
             ...mapGetters(['getCurrentUser']),
             ...mapGetters('aries', {getAriesInstance: 'getInstance'}),
-            ...mapActions('aries', {initAries: 'init'}),
             prefillForm: function() {
                 const {issuance, issuer, subject} = getCredentialMetadata(this.credData, this.dataType)
                 this.issuance = issuance

--- a/cmd/user-agent/src/router/index.js
+++ b/cmd/user-agent/src/router/index.js
@@ -65,7 +65,8 @@ const routes = [
             {
                 path: "connections",
                 name: "connections",
-                component: Connections
+                component: Connections,
+                meta: {requiresAuth: true}
             },
             {
                 path: "relationships",
@@ -76,12 +77,14 @@ const routes = [
             {
                 path: "issue-credential",
                 name: "issue-credential",
-                component: IssueCredential
+                component: IssueCredential,
+                meta: {requiresAuth: true}
             },
             {
                 path: "present-proof",
                 name: "present-proof",
-                component: PresentProof
+                component: PresentProof,
+                meta: {requiresAuth: true}
             }
         ]
     },

--- a/cmd/user-agent/src/store/modules/connections.js
+++ b/cmd/user-agent/src/store/modules/connections.js
@@ -14,9 +14,10 @@ export default {
 
             dispatch('queryConnections')
         },
-        async queryConnections({commit}) {
+        async queryConnections({commit, getters}) {
+            let aries = getters['aries/getInstance']
             // retrieves all agent connections
-            let res = await window.$aries.didexchange.queryConnections()
+            let res = await aries.didexchange.queryConnections()
             if (res.hasOwnProperty('results')) {
                 // sets connections
                 commit('updateConnections', res.results)
@@ -25,17 +26,20 @@ export default {
             return res.results
         },
         async createInvitation(ctx, label) {
+            let aries = ctx.getters['aries/getInstance']
             // creates invitation through the out-of-band protocol
-            let res = await window.$aries.outofband.createInvitation({label: label})
+            let res = await aries.outofband.createInvitation({label: label})
 
             return res.invitation
         },
-        acceptExchangeRequest({dispatch}, id) {
-            window.$aries.didexchange.acceptExchangeRequest({id: id}).then(() => dispatch('queryConnections'))
+        acceptExchangeRequest({dispatch, getters}, id) {
+            let aries = getters['aries/getInstance']
+            aries.didexchange.acceptExchangeRequest({id: id}).then(() => dispatch('queryConnections'))
         },
-        async acceptInvitation({dispatch}, payload) {
+        async acceptInvitation({dispatch, getters}, payload) {
+            let aries = getters['aries/getInstance']
             // accepts invitation thought out-of-band protocol
-            let res = await window.$aries.outofband.acceptInvitation(payload)
+            let res = await aries.outofband.acceptInvitation(payload)
 
             dispatch('queryConnections')
 

--- a/cmd/user-agent/src/store/modules/credentials.js
+++ b/cmd/user-agent/src/store/modules/credentials.js
@@ -15,8 +15,9 @@ export default {
             dispatch('getCredentials')
         },
         async getCredentials({commit, getters}) {
+            let aries = getters['aries/getInstance']
             // retrieves all agent credentials
-            let res = await window.$aries.verifiable.getCredentials()
+            let res = await aries.verifiable.getCredentials()
             if (!res.hasOwnProperty('result')) {
                 return
             }

--- a/cmd/user-agent/src/store/modules/init.js
+++ b/cmd/user-agent/src/store/modules/init.js
@@ -4,6 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
+// deprecated, TODO to be removed
 export default {
     actions: {
         async initStore({dispatch, commit, getters}, opts) {

--- a/cmd/user-agent/src/store/modules/mediator.js
+++ b/cmd/user-agent/src/store/modules/mediator.js
@@ -14,8 +14,9 @@ const errRouterNotRegistered = 'router not registered'
 
 export default {
     actions: {
-        async loadMediatorState({commit}) {
-            let res = await window.$aries.mediator.getConnection().catch(err => {
+        async loadMediatorState({commit, getters}) {
+            let aries = getters['aries/getInstance']
+            let res = await aries.mediator.getConnection().catch(err => {
                 if (!err.message.includes(errRouterNotRegistered)) {
                     throw err
                 }
@@ -33,7 +34,8 @@ export default {
                 return
             }
 
-            await window.$aries.mediator.unregister({id: getters.getMediatorConnID})
+            let aries = getters['aries/getInstance']
+            await aries.mediator.unregister({id: getters.getMediatorConnID})
             commit('updateMediatorConnID', '')
         },
         async registeredMediator({dispatch, getters}, routerURL) {
@@ -47,14 +49,15 @@ export default {
 
             let connID = conn['connection_id']
 
-            await waitForEvent(window.$aries, {
+            let aries = getters['aries/getInstance']
+            await waitForEvent(aries, {
                 type: POST_STATE,
                 stateID: stateCompleted,
                 connectionID: connID,
                 topic: topicDidExchangeStates,
             })
 
-            await window.$aries.mediator.register({connectionID: connID})
+            await aries.mediator.register({connectionID: connID})
 
             await dispatch('loadMediatorState')
         },

--- a/cmd/user-agent/src/store/modules/presentation.js
+++ b/cmd/user-agent/src/store/modules/presentation.js
@@ -15,8 +15,9 @@ export default {
             dispatch('getPresentations')
         },
         async getPresentations({commit, getters}) {
+            let aries = getters['aries/getInstance']
             // retrieves all agent credentials
-            let res = await window.$aries.verifiable.getPresentations()
+            let res = await aries.verifiable.getPresentations()
             if (!res.hasOwnProperty('result')) {
                 return
             }


### PR DESCRIPTION
- no more 'window.$aries', demos pages will reuse webwallet aries
instance
- improved CHAPI window performance by moving major demo pages related (non CHAPI) 
'loading/initialization' to respective vue modules.
- many more refactoring
- closes #352 

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>