### PR TITLE
feat: #375 OIDC callback endpoint

### DIFF
--- a/cmd/http-server/startcmd/start.go
+++ b/cmd/http-server/startcmd/start.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/lpar/gzipped"
 	"github.com/spf13/cobra"
+	oidc2 "github.com/trustbloc/edge-agent/pkg/restapi/common/oidc"
 	"github.com/trustbloc/edge-agent/pkg/restapi/oidc"
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/edge-core/pkg/storage/memstore"
@@ -650,13 +651,16 @@ func addOIDCHandlers(router *mux.Router, config *httpServerParameters) error {
 	}
 
 	oidcOps, err := oidc.New(&oidc.Config{
-		OIDC: &oidc.OIDCConfig{
-			Provider:     &oidc.OIDCProviderImpl{OP: provider},
+		UIEndpoint: uiBasePath,
+		TLSConfig:  config.tls.config,
+		OIDCClient: oidc2.NewClient(&oidc2.Config{
+			TLSConfig:    config.tls.config,
+			Provider:     &oidc2.OIDCProviderAdapter{OP: provider},
+			CallbackURL:  config.oidc.callbackURL,
 			ClientID:     config.oidc.clientID,
 			ClientSecret: config.oidc.clientSecret,
 			Scopes:       []string{oidcp.ScopeOpenID, "profile", "email"},
-			CallbackURL:  config.oidc.callbackURL,
-		},
+		}),
 		Storage: &oidc.StorageConfig{
 			Storage:          memstore.NewProvider(),
 			TransientStorage: memstore.NewProvider(),

--- a/pkg/restapi/common/oidc/client.go
+++ b/pkg/restapi/common/oidc/client.go
@@ -1,0 +1,154 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oidc
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	"github.com/coreos/go-oidc"
+	"golang.org/x/oauth2"
+)
+
+// OIDCProvider provides discovery of OIDC provider endpoints and also verifies id_tokens.
+type OIDCProvider interface {
+	Endpoint() oauth2.Endpoint
+	Verifier(*oidc.Config) OIDCVerifier
+}
+
+// OIDCProviderAdapter adapts an *oidc.Provider into an OIDCProvider.
+type OIDCProviderAdapter struct {
+	OP *oidc.Provider
+}
+
+func (o *OIDCProviderAdapter) Endpoint() oauth2.Endpoint {
+	return o.OP.Endpoint()
+}
+
+func (o *OIDCProviderAdapter) Verifier(config *oidc.Config) OIDCVerifier {
+	return &verifierAdapter{v: o.OP.Verifier(config)}
+}
+
+// OIDCVerifier parses and verifies a raw id_token.
+type OIDCVerifier interface {
+	Verify(ctx context.Context, rawIDToken string) (*oidc.IDToken, error)
+}
+
+type verifierAdapter struct {
+	v *oidc.IDTokenVerifier
+}
+
+func (v *verifierAdapter) Verify(ctx context.Context, token string) (*oidc.IDToken, error) {
+	return v.v.Verify(ctx, token)
+}
+
+// IDToken is the OIDC id_token.
+type IDToken interface {
+	Claims(interface{}) error
+}
+
+type oauth2Config interface {
+	AuthCodeURL(string, ...oauth2.AuthCodeOption) string
+	Exchange(context.Context, string, ...oauth2.AuthCodeOption) (*oauth2.Token, error)
+}
+
+type oauth2ConfigImpl struct {
+	oc *oauth2.Config
+}
+
+func (o *oauth2ConfigImpl) AuthCodeURL(state string, options ...oauth2.AuthCodeOption) string {
+	return o.oc.AuthCodeURL(state, options...)
+}
+
+func (o *oauth2ConfigImpl) Exchange(
+	ctx context.Context, code string, options ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return o.oc.Exchange(ctx, code, options...)
+}
+
+// OAuth2Token is the oauth2.Token.
+type OAuth2Token interface {
+	Extra(string) interface{}
+	Valid() bool
+}
+
+// Client for oidc
+type Client struct {
+	provider     OIDCProvider
+	oauth2ConfigSupplier func() oauth2Config
+	clientID     string
+	tlsConfig    *tls.Config
+}
+
+// Config defines configuration for oidc client.
+type Config struct {
+	TLSConfig    *tls.Config
+	Provider     OIDCProvider
+	CallbackURL  string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+}
+
+// NewClient returns new client instance
+func NewClient(config *Config) *Client {
+	return &Client{
+		provider:     config.Provider,
+		oauth2ConfigSupplier: func() oauth2Config {
+			return &oauth2ConfigImpl{oc: &oauth2.Config{
+				ClientID:     config.ClientID,
+				ClientSecret: config.ClientSecret,
+				Endpoint:     config.Provider.Endpoint(),
+				RedirectURL:  config.CallbackURL,
+				Scopes:       config.Scopes,
+			}}
+		},
+		clientID:     config.ClientID,
+	}
+}
+
+// FormatRequest returns a correctly-formatted OIDC request.
+func (c *Client) FormatRequest(state string) string {
+	return c.oauth2ConfigSupplier().AuthCodeURL(state)
+}
+
+// Exchange the auth code for the OAuth2 token.
+func (c *Client) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
+	token, err := c.oauth2ConfigSupplier().Exchange(
+		context.WithValue(
+			ctx,
+			oauth2.HTTPClient,
+			&http.Client{Transport: &http.Transport{TLSClientConfig: c.tlsConfig}},
+		),
+		code,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exchange code for token: %w", err)
+	}
+
+	if !token.Valid() {
+		return nil, fmt.Errorf("server returned an invalid token")
+	}
+
+	return token, nil
+}
+
+// VerifyIDToken parses the id_token within the OAuth2 token and verifies it.
+func (c *Client) VerifyIDToken(ctx context.Context, oauthToken OAuth2Token) (IDToken, error) {
+	rawIDToken, found := oauthToken.Extra("id_token").(string)
+	if !found {
+		return nil, fmt.Errorf("missing id_token")
+	}
+
+	idToken, err := c.provider.Verifier(&oidc.Config{ClientID: c.clientID}).Verify(ctx, rawIDToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify id_token: %w", err)
+	}
+
+	return idToken, nil
+}

--- a/pkg/restapi/common/oidc/client_test.go
+++ b/pkg/restapi/common/oidc/client_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestClient_FormatRequest(t *testing.T) {
+	t.Run("formats request", func(t *testing.T) {
+		state := uuid.New().String()
+		clientID := uuid.New().String()
+		callbackURL := "http://test.com/callback"
+		scopes := []string{"scopeA", "scopeB", "scopeC"}
+		endpoint := oauth2.Endpoint{
+			AuthURL:  "http://test.com/oauth2/authorize",
+			TokenURL: "http://test.com/oauth2/token",
+		}
+		expected := (&oauth2.Config{
+			ClientID:    clientID,
+			Endpoint:    endpoint,
+			RedirectURL: callbackURL,
+			Scopes:      scopes,
+		}).AuthCodeURL(state)
+		result := NewClient(&Config{
+			Provider:    &mockOIDCProvider{endpoint: endpoint},
+			ClientID:    clientID,
+			CallbackURL: callbackURL,
+			Scopes:      scopes,
+		}).FormatRequest(state)
+		require.Equal(t, expected, result)
+	})
+}
+
+func TestClient_Exchange(t *testing.T) {
+	t.Run("exchanges code for token", func(t *testing.T) {
+		expected := &oauth2.Token{
+			AccessToken:  uuid.New().String(),
+			RefreshToken: uuid.New().String(),
+		}
+		c := NewClient(&Config{
+			Provider:     &mockOIDCProvider{},
+			CallbackURL:  "http://test.com/callback",
+			ClientID:     uuid.New().String(),
+			ClientSecret: uuid.New().String(),
+			Scopes:       []string{"scope1", "scope2"},
+		})
+		c.oauth2ConfigSupplier = func() oauth2Config {
+			return &mockOAuth2Config{
+				token: expected,
+			}
+		}
+		result, err := c.Exchange(context.Background(), "code")
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("error if cannot exchange code for token", func(t *testing.T) {
+		expected := errors.New("test")
+		c := NewClient(&Config{
+			Provider:     &mockOIDCProvider{},
+			CallbackURL:  "http://test.com/callback",
+			ClientID:     uuid.New().String(),
+			ClientSecret: uuid.New().String(),
+			Scopes:       []string{"scope1", "scope2"},
+		})
+		c.oauth2ConfigSupplier = func() oauth2Config {
+			return &mockOAuth2Config{
+				tokenErr: expected,
+			}
+		}
+		_, err := c.Exchange(context.Background(), "code")
+		require.True(t, errors.Is(err, expected))
+	})
+
+	t.Run("error if returned token is invalid", func(t *testing.T) {
+		c := NewClient(&Config{
+			Provider:     &mockOIDCProvider{},
+			CallbackURL:  "http://test.com/callback",
+			ClientID:     uuid.New().String(),
+			ClientSecret: uuid.New().String(),
+			Scopes:       []string{"scope1", "scope2"},
+		})
+		c.oauth2ConfigSupplier = func() oauth2Config {
+			return &mockOAuth2Config{}
+		}
+		_, err := c.Exchange(context.Background(), "code")
+		require.Error(t, err)
+	})
+}
+
+func TestClient_VerifyIDToken(t *testing.T) {
+	t.Run("verifies token", func(t *testing.T) {
+		expected := &oidc.IDToken{
+			Issuer:   "http://test.issuer.com",
+			Subject:  uuid.New().String(),
+			IssuedAt: time.Now(),
+			Nonce:    uuid.New().String(),
+		}
+		c := NewClient(&Config{
+			Provider: &mockOIDCProvider{
+				verifier: &mockOIDCVerifier{
+					token: expected,
+				},
+			},
+			CallbackURL:  "http://test.com/callback",
+			ClientID:     uuid.New().String(),
+			ClientSecret: uuid.New().String(),
+			Scopes:       []string{"scope1", "scope2"},
+		})
+		result, err := c.VerifyIDToken(context.Background(), &mockOAuthToken{extra: uuid.New().String()})
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("error if id_token is missing", func(t *testing.T) {
+		c := NewClient(&Config{
+			Provider: &mockOIDCProvider{
+				verifier: &mockOIDCVerifier{},
+			},
+			CallbackURL:  "http://test.com/callback",
+			ClientID:     uuid.New().String(),
+			ClientSecret: uuid.New().String(),
+			Scopes:       []string{"scope1", "scope2"},
+		})
+		_, err := c.VerifyIDToken(context.Background(), &mockOAuthToken{})
+		require.Error(t, err)
+	})
+
+	t.Run("error if cannot verify id_token", func(t *testing.T) {
+		expected := errors.New("test")
+		c := NewClient(&Config{
+			Provider: &mockOIDCProvider{
+				verifier: &mockOIDCVerifier{err: expected},
+			},
+			CallbackURL:  "http://test.com/callback",
+			ClientID:     uuid.New().String(),
+			ClientSecret: uuid.New().String(),
+			Scopes:       []string{"scope1", "scope2"},
+		})
+		_, err := c.VerifyIDToken(context.Background(), &mockOAuthToken{extra: uuid.New().String()})
+		require.True(t, errors.Is(err, expected))
+	})
+}
+
+type mockOIDCProvider struct {
+	endpoint oauth2.Endpoint
+	verifier OIDCVerifier
+}
+
+func (m *mockOIDCProvider) Endpoint() oauth2.Endpoint {
+	return m.endpoint
+}
+
+func (m *mockOIDCProvider) Verifier(config *oidc.Config) OIDCVerifier {
+	return m.verifier
+}
+
+type mockOAuth2Config struct {
+	token    *oauth2.Token
+	tokenErr error
+}
+
+func (m *mockOAuth2Config) AuthCodeURL(_ string, _ ...oauth2.AuthCodeOption) string {
+	panic("implement me")
+}
+
+func (m *mockOAuth2Config) Exchange(_ context.Context, _ string, _ ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return m.token, m.tokenErr
+}
+
+type mockOAuthToken struct {
+	extra interface{}
+	valid bool
+}
+
+func (m *mockOAuthToken) Extra(_ string) interface{} {
+	return m.extra
+}
+
+func (m *mockOAuthToken) Valid() bool {
+	return m.valid
+}
+
+type mockOIDCVerifier struct {
+	token *oidc.IDToken
+	err   error
+}
+
+func (m *mockOIDCVerifier) Verify(_ context.Context, _ string) (*oidc.IDToken, error) {
+	return m.token, m.err
+}
+
+func mockOIDCProviderService(t *testing.T) string {
+	h := &testOIDCProvider{}
+	srv := httptest.NewServer(h)
+	h.baseURL = srv.URL
+
+	t.Cleanup(srv.Close)
+
+	return srv.URL
+}
+
+type oidcConfigJSON struct {
+	Issuer      string   `json:"issuer"`
+	AuthURL     string   `json:"authorization_endpoint"`
+	TokenURL    string   `json:"token_endpoint"`
+	JWKSURL     string   `json:"jwks_uri"`
+	UserInfoURL string   `json:"userinfo_endpoint"`
+	Algorithms  []string `json:"id_token_signing_alg_values_supported"`
+}
+
+type testOIDCProvider struct {
+	baseURL string
+}
+
+func (t *testOIDCProvider) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	response, err := json.Marshal(&oidcConfigJSON{
+		Issuer:      t.baseURL,
+		AuthURL:     fmt.Sprintf("%s/oauth2/auth", t.baseURL),
+		TokenURL:    fmt.Sprintf("%s/oauth2/token", t.baseURL),
+		JWKSURL:     fmt.Sprintf("%s/oauth2/certs", t.baseURL),
+		UserInfoURL: fmt.Sprintf("%s/oauth2/userinfo", t.baseURL),
+		Algorithms:  []string{"RS256"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = w.Write(response)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/restapi/oidc/dependencies.go
+++ b/pkg/restapi/oidc/dependencies.go
@@ -8,44 +8,14 @@ package oidc
 
 import (
 	"context"
-	"github.com/coreos/go-oidc"
+	oidc2 "github.com/trustbloc/edge-agent/pkg/restapi/common/oidc"
 	"golang.org/x/oauth2"
 )
 
-// OIDCProvider is the OIDC identity provider.
-type OIDCProvider interface {
-	Endpoint() oauth2.Endpoint
-	Verifier(*oidc.Config) Verifier
-}
-
-// Verifier verifies id_tokens.
-type Verifier interface {
-	Verify(context.Context, string) (idToken, error)
-}
-
-// OIDCProviderImpl adapts an *oidc.Provider into an OIDCProvider.
-type OIDCProviderImpl struct {
-	OP *oidc.Provider
-}
-
-// Verifier returns a Verifier.
-func (o *OIDCProviderImpl) Verifier(config *oidc.Config) Verifier {
-	return &verifierImpl{v: o.OP.Verifier(config)}
-}
-
-// Endpoint returns the OIDC provider's endpoints.
-func (o *OIDCProviderImpl) Endpoint() oauth2.Endpoint {
-	return o.OP.Endpoint()
-}
-
-type verifierImpl struct {
-	v *oidc.IDTokenVerifier
-}
-
-func (v *verifierImpl) Verify(ctx context.Context, token string) (idToken, error) {
-	return v.v.Verify(ctx, token)
-}
-
-type idToken interface {
-	Claims(interface{}) error
+// OIDCClient is capable of formatting authorization requests, exchanging the token grant for an access_token
+// and id_token, and verifying id_tokens.
+type OIDCClient interface {
+	FormatRequest(state string) string
+	Exchange(c context.Context, code string) (*oauth2.Token, error)
+	VerifyIDToken(c context.Context, oauthToken oidc2.OAuth2Token) (oidc2.IDToken, error)
 }

--- a/pkg/restapi/oidc/helper.go
+++ b/pkg/restapi/oidc/helper.go
@@ -20,3 +20,12 @@ func openStore(p storage.Provider, name string) (storage.Store, error) {
 
 	return p.OpenStore(name)
 }
+
+// validation rules on the received user claims from the OIDC provider go here
+func evaluateClaims(u *endUser) error {
+	if u.Sub == "" {
+		return fmt.Errorf("empty 'sub' in end user claims")
+	}
+
+	return nil
+}

--- a/pkg/restapi/oidc/operations.go
+++ b/pkg/restapi/oidc/operations.go
@@ -7,44 +7,41 @@ SPDX-License-Identifier: Apache-2.0
 package oidc
 
 import (
+	"context"
+	"crypto/tls"
+	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"net/http"
 
-	"golang.org/x/oauth2"
-
+	"github.com/google/uuid"
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/edge-core/pkg/storage"
+	"golang.org/x/oauth2"
 
 	"github.com/trustbloc/edge-agent/pkg/restapi/common"
 )
 
 // Endpoints.
 const (
-	oidcLoginPath    = "/oidc/login"
-	oidcCallbackPath = "/oidc/callback"
+	oidcLoginPath    = "/login"
+	oidcCallbackPath = "/callback"
 )
 
-// Misc.
+// Stores.
 const (
-	transientStoreName = "hubauth_trx"
+	transientStoreName = "edgeagent_trx"
+	userStoreName      = "edgeagent_users"
+	tokenStoreName     = "edgeagent_tks"
 )
 
 var logger = log.New("hub-auth/oidc")
 
 // Config holds all configuration for an Operation.
 type Config struct {
-	OIDC    *OIDCConfig
-	Storage *StorageConfig
-}
-
-// OIDCConfig holds OIDC config.
-type OIDCConfig struct {
-	Provider     OIDCProvider
-	ClientID     string
-	ClientSecret string
-	Scopes       []string
-	CallbackURL  string
+	OIDCClient OIDCClient
+	Storage    *StorageConfig
+	UIEndpoint string
+	TLSConfig  *tls.Config
 }
 
 // StorageConfig holds storage config.
@@ -53,23 +50,44 @@ type StorageConfig struct {
 	TransientStorage storage.Provider
 }
 
+type store struct {
+	users     storage.Store
+	tokens    storage.Store
+	transient storage.Store
+}
+
 // Operation implements OIDC operations.
 type Operation struct {
-	transientStore storage.Store
-	oidcConfig     *OIDCConfig
+	store      *store
+	oidcClient OIDCClient
+	uiEndpoint string
+	tlsConfig  *tls.Config
 }
 
 // New returns a new Operation.
 func New(config *Config) (*Operation, error) {
 	op := &Operation{
-		oidcConfig: config.OIDC,
+		oidcClient: config.OIDCClient,
+		store:      &store{},
+		uiEndpoint: config.UIEndpoint,
+		tlsConfig:  config.TLSConfig,
 	}
 
 	var err error
 
-	op.transientStore, err = openStore(config.Storage.TransientStorage, transientStoreName)
+	op.store.transient, err = openStore(config.Storage.TransientStorage, transientStoreName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open transient store: %w", err)
+	}
+
+	op.store.users, err = openStore(config.Storage.Storage, userStoreName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open users store: %w", err)
+	}
+
+	op.store.tokens, err = openStore(config.Storage.Storage, tokenStoreName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open tokens store: %w", err)
 	}
 
 	return op, nil
@@ -79,23 +97,16 @@ func New(config *Config) (*Operation, error) {
 func (o *Operation) GetRESTHandlers() []common.Handler {
 	return []common.Handler{
 		common.NewHTTPHandler(oidcLoginPath, http.MethodGet, o.oidcLoginHandler),
+		common.NewHTTPHandler(oidcCallbackPath, http.MethodGet, o.oidcCallbackHandler),
 	}
 }
 
 func (o *Operation) oidcLoginHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Debugf("handling login request: %s", r.URL.String())
 
-	oauth2Config := oauth2.Config{
-		ClientID:     o.oidcConfig.ClientID,
-		ClientSecret: o.oidcConfig.ClientSecret,
-		Endpoint:     o.oidcConfig.Provider.Endpoint(),
-		RedirectURL:  o.oidcConfig.CallbackURL,
-		Scopes:       o.oidcConfig.Scopes,
-	}
-
 	state := uuid.New().String()
 
-	err := newTransientData(o.transientStore).Put(state, state)
+	err := newTransientData(o.store.transient).Put(state, state)
 	if err != nil {
 		common.WriteErrorResponsef(w, logger,
 			http.StatusInternalServerError, "failed to save state to store: %s", err.Error())
@@ -103,8 +114,108 @@ func (o *Operation) oidcLoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	redirectURL := oauth2Config.AuthCodeURL(state)
+	redirectURL := o.oidcClient.FormatRequest(state)
 
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 	logger.Debugf("redirected to login url: %s", redirectURL)
+}
+
+// TODO setup session cookies: https://github.com/trustbloc/edge-agent/issues/379
+// TODO encrypt data before storing: https://github.com/trustbloc/edge-agent/issues/380
+func (o *Operation) oidcCallbackHandler(w http.ResponseWriter, r *http.Request) {
+	logger.Debugf("handling oidc callback: %s", r.URL.String())
+
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		common.WriteErrorResponsef(w, logger, http.StatusBadRequest, "missing state parameter")
+
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		common.WriteErrorResponsef(w, logger, http.StatusBadRequest, "missing code parameter")
+
+		return
+	}
+
+	_, err := o.store.transient.Get(state)
+	if errors.Is(err, storage.ErrValueNotFound) {
+		common.WriteErrorResponsef(w, logger, http.StatusBadRequest, "invalid state parameter")
+
+		return
+	}
+
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusInternalServerError, "unable to query transient store: %s", err.Error())
+
+		return
+	}
+
+	err = o.store.transient.Delete(state)
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusInternalServerError, "failed to delete state from transient store: %s", err.Error())
+
+		return
+	}
+
+	oauthToken, err := o.oidcClient.Exchange(
+		context.WithValue(
+			r.Context(),
+			oauth2.HTTPClient,
+			&http.Client{Transport: &http.Transport{TLSClientConfig: o.tlsConfig}},
+		),
+		code,
+	)
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusBadGateway, "unable to exchange code for token: %s", err.Error())
+
+		return
+	}
+
+	oidcToken, err := o.oidcClient.VerifyIDToken(r.Context(), oauthToken)
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusBadGateway, "cannot verify id_token: %s", err.Error())
+
+		return
+	}
+
+	// TODO only save new user if one doesn't already exist in the store for the given `sub`:
+	//  https://github.com/trustbloc/edge-agent/issues/381
+	user := &endUser{ID: uuid.New().String()}
+
+	err = user.parse(oidcToken)
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusInternalServerError, "failed to parse id_token: %s", err.Error())
+
+		return
+	}
+
+	err = newPersistedData(o.store.users).put(user.ID, user)
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusInternalServerError, "failed to persist user data: %s", err.Error())
+
+		return
+	}
+
+	err = newPersistedData(o.store.tokens).put(user.ID, &endUserTokens{
+		ID:      user.ID,
+		Access:  oauthToken.AccessToken,
+		Refresh: oauthToken.RefreshToken,
+	})
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusInternalServerError, "failed to persist user tokens: %s", err.Error())
+
+		return
+	}
+
+	http.Redirect(w, r, o.uiEndpoint, http.StatusFound)
+	logger.Debugf("redirected user to: %s", o.uiEndpoint)
 }

--- a/pkg/restapi/oidc/operations_test.go
+++ b/pkg/restapi/oidc/operations_test.go
@@ -8,20 +8,20 @@ package oidc
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/trustbloc/edge-core/pkg/storage"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	oidc2 "github.com/trustbloc/edge-agent/pkg/restapi/common/oidc"
+	"github.com/trustbloc/edge-core/pkg/storage"
+	"github.com/trustbloc/edge-core/pkg/storage/memstore"
 	"github.com/trustbloc/edge-core/pkg/storage/mockstore"
+	"golang.org/x/oauth2"
 
-	"github.com/coreos/go-oidc"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"github.com/trustbloc/edge-core/pkg/storage/memstore"
 )
 
 func TestNew(t *testing.T) {
@@ -62,6 +62,24 @@ func TestNew(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, errors.Is(err, expected))
 	})
+
+	t.Run("error if cannot open user store", func(t *testing.T) {
+		config := config(t)
+		config.Storage.Storage = &mockstore.Provider{
+			FailNameSpace:      userStoreName,
+		}
+		_, err := New(config)
+		require.Error(t, err)
+	})
+
+	t.Run("error if cannot open token store", func(t *testing.T) {
+		config := config(t)
+		config.Storage.Storage = &mockstore.Provider{
+			FailNameSpace:      tokenStoreName,
+		}
+		_, err := New(config)
+		require.Error(t, err)
+	})
 }
 
 func TestOperation_GetRESTHandlers(t *testing.T) {
@@ -71,12 +89,12 @@ func TestOperation_GetRESTHandlers(t *testing.T) {
 	require.NotEmpty(t, o.GetRESTHandlers())
 }
 
-func TestOperation_OIDCRequestHandler(t *testing.T) {
+func TestOperation_OIDCLoginHandler(t *testing.T) {
 	t.Run("redirects to OIDC provider", func(t *testing.T) {
 		o, err := New(config(t))
 		require.NoError(t, err)
 		w := httptest.NewRecorder()
-		o.oidcLoginHandler(w, newOIDCHTTPRequest())
+		o.oidcLoginHandler(w, newOIDCLoginRequest())
 		require.Equal(t, http.StatusFound, w.Code)
 		require.NotEmpty(t, w.Header().Get("Location"))
 	})
@@ -92,27 +110,220 @@ func TestOperation_OIDCRequestHandler(t *testing.T) {
 		o, err := New(config)
 		require.NoError(t, err)
 		w := httptest.NewRecorder()
-		o.oidcLoginHandler(w, newOIDCHTTPRequest())
+		o.oidcLoginHandler(w, newOIDCLoginRequest())
 		require.Equal(t, http.StatusInternalServerError, w.Code)
 	})
 }
 
-func newOIDCHTTPRequest() *http.Request {
+func TestOperation_OIDCCallbackHandler(t *testing.T) {
+	t.Run("fetches OIDC tokens and redirects to the UI", func(t *testing.T) {
+		uiEndpoint := "http://test.com/wallet/"
+		code := uuid.New().String()
+		state := uuid.New().String()
+
+		config := config(t)
+		config.UIEndpoint = uiEndpoint
+		config.Storage.TransientStorage = &mockstore.Provider{
+			Store: &mockstore.MockStore{
+				Store: map[string][]byte{
+					state: []byte(state),
+				},
+			},
+		}
+		config.OIDCClient = &mockOIDCClient{
+			oauthToken: &oauth2.Token{
+				AccessToken:  uuid.New().String(),
+				RefreshToken: uuid.New().String(),
+				TokenType:    "Bearer",
+			},
+			idToken: &mockIDToken{
+				claimsFunc: func(i interface{}) error {
+					user, ok := i.(*endUser)
+					require.True(t, ok)
+					user.Sub = uuid.New().String()
+					return nil
+				},
+			},
+		}
+
+		o, err := New(config)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		o.oidcCallbackHandler(w, newOIDCCallbackRequest(code, state))
+
+		require.Equal(t, http.StatusFound, w.Code)
+		require.Equal(t, uiEndpoint, w.Header().Get("Location"))
+	})
+
+	t.Run("error bad request if state query param is missing", func(t *testing.T) {
+		o, err := New(config(t))
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		o.oidcCallbackHandler(w, newOIDCCallbackRequest("code", ""))
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("error bad request if state query param is invalid", func(t *testing.T) {
+		o, err := New(config(t))
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		o.oidcCallbackHandler(w, newOIDCCallbackRequest("code", "INVALID"))
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("error bad request if code query param is missing", func(t *testing.T) {
+		o, err := New(config(t))
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		o.oidcCallbackHandler(w, newOIDCCallbackRequest("", "state"))
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("error internal server error if cannot query transient store", func(t *testing.T) {
+		state := uuid.New().String()
+		config := config(t)
+		config.Storage.TransientStorage = &mockstore.Provider{
+			Store: &mockstore.MockStore{
+				Store:  map[string][]byte{
+					state: []byte(state),
+				},
+				ErrGet: errors.New("test"),
+			},
+		}
+		o, err := New(config)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		o.oidcCallbackHandler(w, newOIDCCallbackRequest("code", state))
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("error internal server error if cannot delete transient state", func(t *testing.T) {
+		state := uuid.New().String()
+		config := config(t)
+		config.Storage.TransientStorage = &mockstore.Provider{
+			Store: &mockstore.MockStore{
+				Store:  map[string][]byte{
+					state: []byte(state),
+				},
+				ErrDelete: errors.New("test"),
+			},
+		}
+		o, err := New(config)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		o.oidcCallbackHandler(w, newOIDCCallbackRequest("code", state))
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("error bad gateway if cannot exchange code for token", func(t *testing.T) {
+		state := uuid.New().String()
+		config := config(t)
+		config.Storage.TransientStorage = &mockstore.Provider{
+			Store: &mockstore.MockStore{
+				Store:  map[string][]byte{
+					state: []byte(state),
+				},
+			},
+		}
+		config.OIDCClient = &mockOIDCClient{
+			oauthErr: errors.New("test"),
+		}
+		o, err := New(config)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		o.oidcCallbackHandler(w, newOIDCCallbackRequest("code", state))
+		require.Equal(t, http.StatusBadGateway, w.Code)
+	})
+
+	t.Run("error bad gateway if cannot verify id_token", func(t *testing.T) {
+		state := uuid.New().String()
+		config := config(t)
+		config.Storage.TransientStorage = &mockstore.Provider{
+			Store: &mockstore.MockStore{
+				Store:  map[string][]byte{
+					state: []byte(state),
+				},
+			},
+		}
+		config.OIDCClient = &mockOIDCClient{
+			idTokenErr: errors.New("test"),
+		}
+		o, err := New(config)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		o.oidcCallbackHandler(w, newOIDCCallbackRequest("code", state))
+		require.Equal(t, http.StatusBadGateway, w.Code)
+	})
+
+	t.Run("error internal server error if cannot parse id_token", func(t *testing.T) {
+		state := uuid.New().String()
+		config := config(t)
+		config.Storage.TransientStorage = &mockstore.Provider{
+			Store: &mockstore.MockStore{
+				Store:  map[string][]byte{
+					state: []byte(state),
+				},
+			},
+		}
+		config.OIDCClient = &mockOIDCClient{
+			idToken: &mockIDToken{
+				claimsErr: errors.New("test"),
+			},
+		}
+		o, err := New(config)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		o.oidcCallbackHandler(w, newOIDCCallbackRequest("code", state))
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("error internal server error if cannot save to user store", func(t *testing.T) {
+		state := uuid.New().String()
+		config := config(t)
+		config.Storage.TransientStorage = &mockstore.Provider{
+			Store: &mockstore.MockStore{
+				Store:  map[string][]byte{
+					state: []byte(state),
+				},
+			},
+		}
+		config.Storage.Storage = &mockstore.Provider{
+			Store: &mockstore.MockStore{
+				Store:  make(map[string][]byte),
+				ErrPut: errors.New("test"),
+			},
+		}
+		config.OIDCClient = &mockOIDCClient{
+			idToken: &mockIDToken{
+				claimsFunc: func(i interface{}) error {
+					user, ok := i.(*endUser)
+					require.True(t, ok)
+					user.Sub = uuid.New().String()
+					return nil
+				},
+			},
+		}
+		o, err := New(config)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		o.oidcCallbackHandler(w, newOIDCCallbackRequest("code", state))
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}
+
+func newOIDCLoginRequest() *http.Request {
 	return httptest.NewRequest(http.MethodGet, "/oidc/login", nil)
 }
 
+func newOIDCCallbackRequest(code, state string) *http.Request {
+	return httptest.NewRequest(http.MethodGet, fmt.Sprintf("/oidc/callback?code=%s&state=%s", code, state), nil)
+}
+
 func config(t *testing.T) *Config {
-	oidcProvider, err := oidc.NewProvider(context.Background(), newTestOIDCProvider(t))
-	require.NoError(t, err)
+	t.Helper()
 
 	return &Config{
-		OIDC: &OIDCConfig{
-			Provider:     &OIDCProviderImpl{OP: oidcProvider},
-			ClientID:     uuid.New().String(),
-			ClientSecret: uuid.New().String(),
-			Scopes:       []string{oidc.ScopeOpenID, "test"},
-			CallbackURL:  "http://test.com/callback",
-		},
+		OIDCClient: &mockOIDCClient{},
 		Storage: &StorageConfig{
 			Storage:          memstore.NewProvider(),
 			TransientStorage: memstore.NewProvider(),
@@ -120,34 +331,35 @@ func config(t *testing.T) *Config {
 	}
 }
 
-func newTestOIDCProvider(t *testing.T) string {
-	h := &testOIDCProvider{}
-	srv := httptest.NewServer(h)
-	h.baseURL = srv.URL
-	t.Cleanup(srv.Close)
-
-	return srv.URL
+type mockOIDCClient struct {
+	authRequest string
+	oauthToken  *oauth2.Token
+	oauthErr    error
+	idToken     oidc2.IDToken
+	idTokenErr  error
 }
 
-type testOIDCProvider struct {
-	baseURL string
+func (m *mockOIDCClient) FormatRequest(_ string) string {
+	return m.authRequest
 }
 
-func (t *testOIDCProvider) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	response, err := json.Marshal(map[string]interface{}{
-		"issuer":                                t.baseURL,
-		"authorization_endpoint":                fmt.Sprintf("%s/oauth2/auth", t.baseURL),
-		"token_endpoint":                        fmt.Sprintf("%s/oauth2/token", t.baseURL),
-		"jwks_uri":                              fmt.Sprintf("%s/oauth2/certs", t.baseURL),
-		"userinfo_endpoint":                     fmt.Sprintf("%s/oauth2/userinfo", t.baseURL),
-		"id_token_signing_alg_values_supported": []string{"RS256"},
-	})
-	if err != nil {
-		panic(err)
+func (m *mockOIDCClient) Exchange(_ context.Context, _ string) (*oauth2.Token, error) {
+	return m.oauthToken, m.oauthErr
+}
+
+func (m *mockOIDCClient) VerifyIDToken(_ context.Context, _ oidc2.OAuth2Token) (oidc2.IDToken, error) {
+	return m.idToken, m.idTokenErr
+}
+
+type mockIDToken struct {
+	claimsErr  error
+	claimsFunc func(interface{}) error
+}
+
+func (m *mockIDToken) Claims(i interface{}) error {
+	if m.claimsFunc != nil {
+		return m.claimsFunc(i)
 	}
 
-	_, err = w.Write(response)
-	if err != nil {
-		panic(err)
-	}
+	return m.claimsErr
 }

--- a/pkg/restapi/oidc/persistedData.go
+++ b/pkg/restapi/oidc/persistedData.go
@@ -1,0 +1,64 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oidc
+
+import (
+	"encoding/json"
+	"fmt"
+	oidc2 "github.com/trustbloc/edge-agent/pkg/restapi/common/oidc"
+
+	"github.com/trustbloc/edge-core/pkg/storage"
+)
+
+// standard claims: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+type endUser struct {
+	ID         string
+	Sub        string `json:"sub"`
+	Name       string `json:"name"`
+	GivenName  string `json:"given_name"`
+	FamilyName string `json:"family_name"`
+	Email      string `json:"email"`
+}
+
+func (e *endUser) parse(t oidc2.IDToken) error {
+	err := t.Claims(e)
+	if err != nil {
+		return fmt.Errorf("failed to parse claims from id_token: %w", err)
+	}
+
+	err = evaluateClaims(e)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate claims in id_token: %w", err)
+	}
+
+	return nil
+}
+
+type endUserTokens struct {
+	ID      string
+	Access  string
+	Refresh string
+}
+
+type persistedData struct {
+	s storage.Store
+}
+
+func newPersistedData(s storage.Store) *persistedData {
+	return &persistedData{s: s}
+}
+
+func (e *persistedData) put(k string, v interface{}) error {
+	bits, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("failed to marshal value: %w", err)
+	}
+
+	return e.s.Put(k, bits)
+}
+
+


### PR DESCRIPTION
closes #375

This PR provides a skeleton for the OIDC callback endpoint. There are still additional things to do (some of them figured out, some of them are pending final design decisions).

* added a new OIDC `/callback` endpoint
* created a new OIDC client to hide all that complexity. Refactored existing code in the REST operations to use this client
* added new `user` and `tokens` stores to the OIDC REST operations

Signed-off-by: George Aristy <george.aristy@securekey.com>