### PR TITLE
feat: #379 session cookies

### DIFF
--- a/cmd/http-server/go.sum
+++ b/cmd/http-server/go.sum
@@ -101,6 +101,10 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
+github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/cmd/trustbloc-agent-js-worker/go.sum
+++ b/cmd/trustbloc-agent-js-worker/go.sum
@@ -115,6 +115,8 @@ github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORR
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
+	github.com/gorilla/sessions v1.2.1
 	github.com/hyperledger/aries-framework-go v0.1.4
 	github.com/stretchr/testify v1.6.1
 	github.com/trustbloc/edge-core v0.1.5-0.20200916124536-c32454a16108

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,10 @@ github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORR
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
+github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/pkg/restapi/common/common.go
+++ b/pkg/restapi/common/common.go
@@ -28,6 +28,8 @@ type ErrorResponse struct {
 
 // WriteErrorResponsef write error resp.
 func WriteErrorResponsef(rw http.ResponseWriter, logger log.Logger, status int, msg string, args ...interface{}) {
+	logger.Errorf(msg, args...)
+
 	rw.WriteHeader(status)
 
 	err := json.NewEncoder(rw).Encode(ErrorResponse{

--- a/pkg/restapi/oidc/dependencies.go
+++ b/pkg/restapi/oidc/dependencies.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	oidc2 "github.com/trustbloc/edge-agent/pkg/restapi/common/oidc"
 	"golang.org/x/oauth2"
+	"net/http"
 )
 
 // OIDCClient is capable of formatting authorization requests, exchanging the token grant for an access_token
@@ -18,4 +19,17 @@ type OIDCClient interface {
 	FormatRequest(state string) string
 	Exchange(c context.Context, code string) (*oauth2.Token, error)
 	VerifyIDToken(c context.Context, oauthToken oidc2.OAuth2Token) (oidc2.IDToken, error)
+}
+
+// CookieStore has session cookies.
+type CookieStore interface {
+	Get(*http.Request, string) (Cookies, error)
+}
+
+// Cookies are contained within a CookieStore.
+type Cookies interface {
+	Set(k interface{}, v interface{})
+	Get(k interface{}) (interface{}, bool)
+	Delete(k interface{})
+	Save(*http.Request, http.ResponseWriter) error
 }

--- a/pkg/restapi/oidc/helper.go
+++ b/pkg/restapi/oidc/helper.go
@@ -9,7 +9,9 @@ package oidc
 import (
 	"errors"
 	"fmt"
+	"github.com/gorilla/sessions"
 	"github.com/trustbloc/edge-core/pkg/storage"
+	"net/http"
 )
 
 func openStore(p storage.Provider, name string) (storage.Store, error) {
@@ -28,4 +30,39 @@ func evaluateClaims(u *endUser) error {
 	}
 
 	return nil
+}
+
+type cookieStoreAdapter struct {
+	cookieStore *sessions.CookieStore
+}
+
+func (c *cookieStoreAdapter) Get(r *http.Request, name string) (Cookies, error) {
+	session, err := c.cookieStore.Get(r, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user session '%s': %w", name, err)
+	}
+
+	return &sessionsAdapter{session: session}, nil
+}
+
+type sessionsAdapter struct {
+	session *sessions.Session
+}
+
+func (s *sessionsAdapter) Set(k interface{}, v interface{}) {
+	s.session.Values[k] = v
+}
+
+func (s *sessionsAdapter) Get(k interface{}) (interface{}, bool) {
+	v, found := s.session.Values[k]
+
+	return v, found
+}
+
+func (s *sessionsAdapter) Delete(k interface{}) {
+	delete(s.session.Values, k)
+}
+
+func (s *sessionsAdapter) Save(r *http.Request, w http.ResponseWriter) error {
+	return s.session.Save(r, w)
 }

--- a/pkg/restapi/oidc/operations.go
+++ b/pkg/restapi/oidc/operations.go
@@ -9,9 +9,10 @@ package oidc
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/gorilla/sessions"
 
 	"github.com/google/uuid"
 	"github.com/trustbloc/edge-core/pkg/log"
@@ -19,6 +20,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/trustbloc/edge-agent/pkg/restapi/common"
+	"github.com/trustbloc/edge-agent/pkg/restapi/common/oidc"
 )
 
 // Endpoints.
@@ -32,6 +34,8 @@ const (
 	transientStoreName = "edgeagent_trx"
 	userStoreName      = "edgeagent_users"
 	tokenStoreName     = "edgeagent_tks"
+	cookieStoreName    = "edgeagent_wallet"
+	stateCookieName    = "oauth2_state"
 )
 
 var logger = log.New("hub-auth/oidc")
@@ -42,6 +46,12 @@ type Config struct {
 	Storage    *StorageConfig
 	UIEndpoint string
 	TLSConfig  *tls.Config
+	Keys       *KeyConfig
+}
+
+type KeyConfig struct {
+	Auth []byte
+	Enc  []byte
 }
 
 // StorageConfig holds storage config.
@@ -54,6 +64,7 @@ type store struct {
 	users     storage.Store
 	tokens    storage.Store
 	transient storage.Store
+	cookies   CookieStore
 }
 
 // Operation implements OIDC operations.
@@ -66,9 +77,17 @@ type Operation struct {
 
 // New returns a new Operation.
 func New(config *Config) (*Operation, error) {
+	// TODO make session cookies max age configurable: https://github.com/trustbloc/edge-agent/issues/388
+	cookieStore := sessions.NewCookieStore(config.Keys.Auth, config.Keys.Enc)
+	cookieStore.MaxAge(900) // 15 mins
+
 	op := &Operation{
 		oidcClient: config.OIDCClient,
-		store:      &store{},
+		store: &store{
+			cookies: &cookieStoreAdapter{
+				cookieStore: cookieStore,
+			},
+		},
 		uiEndpoint: config.UIEndpoint,
 		tlsConfig:  config.TLSConfig,
 	}
@@ -104,83 +123,36 @@ func (o *Operation) GetRESTHandlers() []common.Handler {
 func (o *Operation) oidcLoginHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Debugf("handling login request: %s", r.URL.String())
 
-	state := uuid.New().String()
-
-	err := newTransientData(o.store.transient).Put(state, state)
+	session, err := o.store.cookies.Get(r, cookieStoreName)
 	if err != nil {
 		common.WriteErrorResponsef(w, logger,
-			http.StatusInternalServerError, "failed to save state to store: %s", err.Error())
+			http.StatusInternalServerError, "failed to create or decode session cookie: %s", err.Error())
 
 		return
 	}
 
+	state := uuid.New().String()
+	session.Set(stateCookieName, state)
 	redirectURL := o.oidcClient.FormatRequest(state)
+
+	err = session.Save(r, w)
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusInternalServerError, "failed to save session cookie: %s", err.Error())
+
+		return
+	}
 
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 	logger.Debugf("redirected to login url: %s", redirectURL)
 }
 
-// TODO setup session cookies: https://github.com/trustbloc/edge-agent/issues/379
 // TODO encrypt data before storing: https://github.com/trustbloc/edge-agent/issues/380
 func (o *Operation) oidcCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Debugf("handling oidc callback: %s", r.URL.String())
 
-	state := r.URL.Query().Get("state")
-	if state == "" {
-		common.WriteErrorResponsef(w, logger, http.StatusBadRequest, "missing state parameter")
-
-		return
-	}
-
-	code := r.URL.Query().Get("code")
-	if code == "" {
-		common.WriteErrorResponsef(w, logger, http.StatusBadRequest, "missing code parameter")
-
-		return
-	}
-
-	_, err := o.store.transient.Get(state)
-	if errors.Is(err, storage.ErrValueNotFound) {
-		common.WriteErrorResponsef(w, logger, http.StatusBadRequest, "invalid state parameter")
-
-		return
-	}
-
-	if err != nil {
-		common.WriteErrorResponsef(w, logger,
-			http.StatusInternalServerError, "unable to query transient store: %s", err.Error())
-
-		return
-	}
-
-	err = o.store.transient.Delete(state)
-	if err != nil {
-		common.WriteErrorResponsef(w, logger,
-			http.StatusInternalServerError, "failed to delete state from transient store: %s", err.Error())
-
-		return
-	}
-
-	oauthToken, err := o.oidcClient.Exchange(
-		context.WithValue(
-			r.Context(),
-			oauth2.HTTPClient,
-			&http.Client{Transport: &http.Transport{TLSClientConfig: o.tlsConfig}},
-		),
-		code,
-	)
-	if err != nil {
-		common.WriteErrorResponsef(w, logger,
-			http.StatusBadGateway, "unable to exchange code for token: %s", err.Error())
-
-		return
-	}
-
-	oidcToken, err := o.oidcClient.VerifyIDToken(r.Context(), oauthToken)
-	if err != nil {
-		common.WriteErrorResponsef(w, logger,
-			http.StatusBadGateway, "cannot verify id_token: %s", err.Error())
-
+	oauthToken, oidcToken, canProceed := o.fetchTokens(w, r)
+	if !canProceed {
 		return
 	}
 
@@ -188,7 +160,7 @@ func (o *Operation) oidcCallbackHandler(w http.ResponseWriter, r *http.Request) 
 	//  https://github.com/trustbloc/edge-agent/issues/381
 	user := &endUser{ID: uuid.New().String()}
 
-	err = user.parse(oidcToken)
+	err := user.parse(oidcToken)
 	if err != nil {
 		common.WriteErrorResponsef(w, logger,
 			http.StatusInternalServerError, "failed to parse id_token: %s", err.Error())
@@ -218,4 +190,77 @@ func (o *Operation) oidcCallbackHandler(w http.ResponseWriter, r *http.Request) 
 
 	http.Redirect(w, r, o.uiEndpoint, http.StatusFound)
 	logger.Debugf("redirected user to: %s", o.uiEndpoint)
+}
+
+func (o *Operation) fetchTokens(
+	w http.ResponseWriter, r *http.Request) (oauthToken *oauth2.Token, oidcToken oidc.IDToken, proceed bool) {
+	session, err := o.store.cookies.Get(r, cookieStoreName)
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusInternalServerError, "failed to create or decode session cookie: %s", err.Error())
+
+		return nil, nil, false
+	}
+
+	stateCookie, found := session.Get(stateCookieName)
+	if !found {
+		common.WriteErrorResponsef(w, logger, http.StatusBadRequest, "missing state session cookie")
+
+		return nil, nil, false
+	}
+
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		common.WriteErrorResponsef(w, logger, http.StatusBadRequest, "missing state parameter")
+
+		return nil, nil, false
+	}
+
+	if state != stateCookie {
+		common.WriteErrorResponsef(w, logger, http.StatusBadRequest, "invalid state parameter")
+
+		return nil, nil, false
+	}
+
+	session.Delete(stateCookieName)
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		common.WriteErrorResponsef(w, logger, http.StatusBadRequest, "missing code parameter")
+
+		return nil, nil, false
+	}
+
+	oauthToken, err = o.oidcClient.Exchange(
+		context.WithValue(
+			r.Context(),
+			oauth2.HTTPClient,
+			&http.Client{Transport: &http.Transport{TLSClientConfig: o.tlsConfig}},
+		),
+		code,
+	)
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusBadGateway, "unable to exchange code for token: %s", err.Error())
+
+		return nil, nil, false
+	}
+
+	oidcToken, err = o.oidcClient.VerifyIDToken(r.Context(), oauthToken)
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusBadGateway, "cannot verify id_token: %s", err.Error())
+
+		return nil, nil, false
+	}
+
+	err = session.Save(r, w)
+	if err != nil {
+		common.WriteErrorResponsef(w, logger,
+			http.StatusInternalServerError, "failed to save session cookies: %s", err.Error())
+
+		return nil, nil, false
+	}
+
+	return oauthToken, oidcToken, true
 }

--- a/scripts/generate_test_keys.sh
+++ b/scripts/generate_test_keys.sh
@@ -38,5 +38,9 @@ openssl ecparam -name prime256v1 -genkey -noout -out test/bdd/fixtures/keys/tls/
 openssl req -new -key test/bdd/fixtures/keys/tls/ec-key.pem -subj "/C=CA/ST=ON/O=Example Inc.:edge-agent/OU=edge-agent/CN=localhost" -out test/bdd/fixtures/keys/tls/ec-key.csr
 openssl x509 -req -in test/bdd/fixtures/keys/tls/ec-key.csr -CA test/bdd/fixtures/keys/tls/ec-cacert.pem -CAkey test/bdd/fixtures/keys/tls/ec-cakey.pem -CAcreateserial -extfile "$tmp" -out test/bdd/fixtures/keys/tls/ec-pubCert.pem -days 365
 
+#create session cookie keys
+mkdir -p test/bdd/fixtures/keys/session_cookies
+openssl rand -out test/bdd/fixtures/keys/session_cookies/auth.key 32
+openssl rand -out test/bdd/fixtures/keys/session_cookies/enc.key 32
 
 echo "done generating edge-agent PKI"

--- a/test/bdd/fixtures/.gitignore
+++ b/test/bdd/fixtures/.gitignore
@@ -1,0 +1,8 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+db/
+keys/

--- a/test/bdd/fixtures/agent-wasm/docker-compose.yml
+++ b/test/bdd/fixtures/agent-wasm/docker-compose.yml
@@ -63,9 +63,9 @@ services:
     environment:
       - HTTP_SERVER_HOST_URL=0.0.0.0:8091
       - ARIESD_HTTP_RESOLVER=${HTTP_RESOLVER}
-      - TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
-      - TLS_KEY_FILE=/etc/tls/ec-key.pem
-      - TLS_CACERTS=/etc/tls/ec-cacert.pem
+      - TLS_CERT_FILE=/etc/keys/tls/ec-pubCert.pem
+      - TLS_KEY_FILE=/etc/keys/tls/ec-key.pem
+      - TLS_CACERTS=/etc/keys/tls/ec-cacert.pem
       - ARIESD_DEFAULT_LABEL=user-agent
       - BLOC_DOMAIN=testnet.trustbloc.local
       - WALLET_MEDIATOR_URL=${WALLET_ROUTER_URL}
@@ -74,10 +74,12 @@ services:
       - HTTP_SERVER_OIDC_CLIENTID=TODO
       - HTTP_SERVER_OIDC_CLIENTSECRET=TODO
       - HTTP_SERVER_OIDC_CALLBACK=http://TODO.com/callback
+      - HTTP_SERVER_COOKIE_AUTH_KEY=/etc/keys/session_cookies/auth.key
+      - HTTP_SERVER_COOKIE_ENC_KEY=/etc/keys/session_cookies/enc.key
     ports:
       - 8091:8091
     volumes:
-      - ../keys/tls:/etc/tls
+      - ../keys:/etc/keys
     command: start
     depends_on:
       - sds.example.com
@@ -89,8 +91,8 @@ services:
     environment:
       - HTTP_SERVER_HOST_URL=0.0.0.0:8071
       - ARIESD_HTTP_RESOLVER=${HTTP_RESOLVER}
-      - TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
-      - TLS_KEY_FILE=/etc/tls/ec-key.pem
+      - TLS_CERT_FILE=/etc/keys/tls/ec-pubCert.pem
+      - TLS_KEY_FILE=/etc/keys/tls/ec-key.pem
       - ARIESD_DEFAULT_LABEL=second-user-agent
       - BLOC_DOMAIN=testnet.trustbloc.local
       - WALLET_MEDIATOR_URL=${WALLET_ROUTER_URL}
@@ -99,10 +101,12 @@ services:
       - HTTP_SERVER_OIDC_CLIENTID=TODO
       - HTTP_SERVER_OIDC_CLIENTSECRET=TODO
       - HTTP_SERVER_OIDC_CALLBACK=http://TODO.com/callback
+      - HTTP_SERVER_COOKIE_AUTH_KEY=/etc/keys/session_cookies/auth.key
+      - HTTP_SERVER_COOKIE_ENC_KEY=/etc/keys/session_cookies/enc.key
     ports:
       - 8071:8071
     volumes:
-      - ../keys/tls:/etc/tls
+      - ../keys:/etc/keys
     command: start
     depends_on:
       - sds.example.com

--- a/test/user-agent/package-lock.json
+++ b/test/user-agent/package-lock.json
@@ -1605,15 +1605,6 @@
           "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
           "optional": true
         },
-        "bindings": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-          "optional": true,
-          "requires": {
-            "file-uri-to-path": "1.0.0"
-          }
-        },
         "bluebird": {
           "version": "3.7.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1848,7 +1839,6 @@
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
             "glob-parent": "~5.1.0",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
@@ -2553,12 +2543,6 @@
             "schema-utils": "^2.7.1"
           }
         },
-        "file-uri-to-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-          "optional": true
-        },
         "fill-range": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2753,12 +2737,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "fsevents": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-          "optional": true
         },
         "get-caller-file": {
           "version": "2.0.5",
@@ -3469,12 +3447,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "nan": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-          "optional": true
         },
         "nanomatch": {
           "version": "1.2.13",
@@ -4841,7 +4813,6 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
@@ -4873,16 +4844,6 @@
                     "is-extendable": "^0.1.0"
                   }
                 }
-              }
-            },
-            "fsevents": {
-              "version": "1.2.13",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-              "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-              "optional": true,
-              "requires": {
-                "bindings": "^1.5.0",
-                "nan": "^2.12.1"
               }
             },
             "glob-parent": {
@@ -5837,15 +5798,6 @@
           "version": "1.13.1",
           "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
           "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
-        },
-        "bindings": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-          "optional": true,
-          "requires": {
-            "file-uri-to-path": "1.0.0"
-          }
         },
         "bluebird": {
           "version": "3.7.2",
@@ -6915,12 +6867,6 @@
             }
           }
         },
-        "file-uri-to-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-          "optional": true
-        },
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -7064,11 +7010,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "fsevents": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ=="
         },
         "get-caller-file": {
           "version": "2.0.5",
@@ -7824,12 +7765,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "nan": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-          "optional": true
         },
         "nanomatch": {
           "version": "1.2.13",
@@ -9155,7 +9090,6 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
@@ -9164,16 +9098,6 @@
                 "path-is-absolute": "^1.0.0",
                 "readdirp": "^2.2.1",
                 "upath": "^1.1.1"
-              }
-            },
-            "fsevents": {
-              "version": "1.2.13",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-              "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-              "optional": true,
-              "requires": {
-                "bindings": "^1.5.0",
-                "nan": "^2.12.1"
               }
             },
             "glob-parent": {
@@ -10884,15 +10808,6 @@
               "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
               "optional": true
             },
-            "bindings": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-              "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-              "optional": true,
-              "requires": {
-                "file-uri-to-path": "1.0.0"
-              }
-            },
             "bluebird": {
               "version": "3.7.2",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -11127,7 +11042,6 @@
               "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.2",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -11832,12 +11746,6 @@
                 "schema-utils": "^2.7.1"
               }
             },
-            "file-uri-to-path": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-              "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-              "optional": true
-            },
             "fill-range": {
               "version": "7.0.1",
               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -12032,12 +11940,6 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-            },
-            "fsevents": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-              "optional": true
             },
             "get-caller-file": {
               "version": "2.0.5",
@@ -12748,12 +12650,6 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
-            "nan": {
-              "version": "2.14.1",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-              "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-              "optional": true
             },
             "nanomatch": {
               "version": "1.2.13",
@@ -14120,7 +14016,6 @@
                     "anymatch": "^2.0.0",
                     "async-each": "^1.0.1",
                     "braces": "^2.3.2",
-                    "fsevents": "^1.2.7",
                     "glob-parent": "^3.1.0",
                     "inherits": "^2.0.3",
                     "is-binary-path": "^1.0.0",
@@ -14152,16 +14047,6 @@
                         "is-extendable": "^0.1.0"
                       }
                     }
-                  }
-                },
-                "fsevents": {
-                  "version": "1.2.13",
-                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-                  "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                  "optional": true,
-                  "requires": {
-                    "bindings": "^1.5.0",
-                    "nan": "^2.12.1"
                   }
                 },
                 "glob-parent": {
@@ -15116,15 +15001,6 @@
               "version": "1.13.1",
               "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
               "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
-            },
-            "bindings": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-              "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-              "optional": true,
-              "requires": {
-                "file-uri-to-path": "1.0.0"
-              }
             },
             "bluebird": {
               "version": "3.7.2",
@@ -16194,12 +16070,6 @@
                 }
               }
             },
-            "file-uri-to-path": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-              "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-              "optional": true
-            },
             "fill-range": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -16343,11 +16213,6 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-            },
-            "fsevents": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ=="
             },
             "get-caller-file": {
               "version": "2.0.5",
@@ -17103,12 +16968,6 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
-            "nan": {
-              "version": "2.14.1",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-              "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-              "optional": true
             },
             "nanomatch": {
               "version": "1.2.13",
@@ -18434,7 +18293,6 @@
                     "anymatch": "^2.0.0",
                     "async-each": "^1.0.1",
                     "braces": "^2.3.2",
-                    "fsevents": "^1.2.7",
                     "glob-parent": "^3.1.0",
                     "inherits": "^2.0.3",
                     "is-binary-path": "^1.0.0",
@@ -18443,16 +18301,6 @@
                     "path-is-absolute": "^1.0.0",
                     "readdirp": "^2.2.1",
                     "upath": "^1.1.1"
-                  }
-                },
-                "fsevents": {
-                  "version": "1.2.13",
-                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-                  "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                  "optional": true,
-                  "requires": {
-                    "bindings": "^1.5.0",
-                    "nan": "^2.12.1"
                   }
                 },
                 "glob-parent": {
@@ -20207,7 +20055,6 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
@@ -22270,553 +22117,6 @@
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
-        "fsevents": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-          "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
-          "optional": true,
-          "requires": {
-            "nan": "^2.12.1",
-            "node-pre-gyp": "^0.12.0"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-              "optional": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": false,
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "optional": true
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.5",
-              "resolved": false,
-              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-              "optional": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              }
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "optional": true
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "resolved": false,
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-              "optional": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "chownr": {
-              "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "optional": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "resolved": false,
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "optional": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "optional": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-              "optional": true
-            },
-            "debug": {
-              "version": "4.1.1",
-              "resolved": false,
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "optional": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "deep-extend": {
-              "version": "0.6.0",
-              "resolved": false,
-              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-              "optional": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-              "optional": true
-            },
-            "detect-libc": {
-              "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-              "optional": true
-            },
-            "fs-minipass": {
-              "version": "1.2.5",
-              "resolved": false,
-              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-              "optional": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-              "optional": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "resolved": false,
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-              "optional": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.3",
-              "resolved": false,
-              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-              "optional": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-              "optional": true
-            },
-            "iconv-lite": {
-              "version": "0.4.24",
-              "resolved": false,
-              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-              "optional": true,
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-              }
-            },
-            "ignore-walk": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-              "optional": true,
-              "requires": {
-                "minimatch": "^3.0.4"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "resolved": false,
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "optional": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": false,
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "optional": true
-            },
-            "ini": {
-              "version": "1.3.5",
-              "resolved": false,
-              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "optional": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "optional": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": false,
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "optional": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": false,
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "optional": true
-            },
-            "minipass": {
-              "version": "2.3.5",
-              "resolved": false,
-              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-              "optional": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            },
-            "minizlib": {
-              "version": "1.2.1",
-              "resolved": false,
-              "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
-              "optional": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": false,
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "optional": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.1.1",
-              "resolved": false,
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "optional": true
-            },
-            "needle": {
-              "version": "2.3.0",
-              "resolved": false,
-              "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
-              "optional": true,
-              "requires": {
-                "debug": "^4.1.0",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
-              }
-            },
-            "node-pre-gyp": {
-              "version": "0.12.0",
-              "resolved": false,
-              "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
-              "optional": true,
-              "requires": {
-                "detect-libc": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "needle": "^2.2.1",
-                "nopt": "^4.0.1",
-                "npm-packlist": "^1.1.6",
-                "npmlog": "^4.0.2",
-                "rc": "^1.2.7",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^4"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-              "optional": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.6",
-              "resolved": false,
-              "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
-              "optional": true
-            },
-            "npm-packlist": {
-              "version": "1.4.1",
-              "resolved": false,
-              "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
-              "optional": true,
-              "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "resolved": false,
-              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": false,
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": false,
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "optional": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.5",
-              "resolved": false,
-              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-              "optional": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.8",
-              "resolved": false,
-              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-              "optional": true,
-              "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "resolved": false,
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-              "optional": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.3",
-              "resolved": false,
-              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-              "optional": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": false,
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "optional": true
-            },
-            "safer-buffer": {
-              "version": "2.1.2",
-              "resolved": false,
-              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-              "optional": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "resolved": false,
-              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-              "optional": true
-            },
-            "semver": {
-              "version": "5.7.0",
-              "resolved": false,
-              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "resolved": false,
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-              "optional": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "optional": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-              "optional": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "optional": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-              "optional": true
-            },
-            "tar": {
-              "version": "4.4.8",
-              "resolved": false,
-              "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
-              "optional": true,
-              "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.4",
-                "minizlib": "^1.1.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-              "optional": true
-            },
-            "wide-align": {
-              "version": "1.1.3",
-              "resolved": false,
-              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-              "optional": true,
-              "requires": {
-                "string-width": "^1.0.2 || 2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "optional": true
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "resolved": false,
-              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-              "optional": true
-            }
-          }
-        },
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -24461,12 +23761,6 @@
             "object-assign": "^4.0.1",
             "thenify-all": "^1.0.0"
           }
-        },
-        "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-          "optional": true
         },
         "nanomatch": {
           "version": "1.2.13",
@@ -29685,9 +28979,9 @@
       }
     },
     "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
       "dev": true
     },
     "base64-js": {
@@ -29722,16 +29016,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "blob": {
       "version": "0.0.5",
@@ -29918,13 +29202,13 @@
       }
     },
     "browserslist": {
-      "version": "4.14.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.4.tgz",
-      "integrity": "sha512-7FOuawafVdEwa5Jv4nzeik/PepAjVte6HmVGHsjt2bC237jeL9QlcTBDF3PnHEvcC6uHwLGYPwZHNZMB7wWAnw==",
+      "version": "4.14.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
+      "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
       "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001135",
-        "electron-to-chromium": "^1.3.570",
+        "electron-to-chromium": "^1.3.571",
         "escalade": "^3.1.0",
         "node-releases": "^1.1.61"
       }
@@ -30060,9 +29344,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001135",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz",
-      "integrity": "sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==",
+      "version": "1.0.30001140",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001140.tgz",
+      "integrity": "sha512-xFtvBtfGrpjTOxTpjP5F2LmN04/ZGfYV8EQzUIC/RmKpdrmzJrjqlJ4ho7sGuAMPko2/Jl08h7x9uObCfBFaAA==",
       "dev": true
     },
     "chai": {
@@ -30782,9 +30066,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.571",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.571.tgz",
-      "integrity": "sha512-UYEQ2Gtc50kqmyOmOVtj6Oqi38lm5yRJY3pLuWt6UIot0No1L09uu6Ja6/1XKwmz/p0eJFZTUZi+khd1PV1hHA==",
+      "version": "1.3.576",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.576.tgz",
+      "integrity": "sha512-uSEI0XZ//5ic+0NdOqlxp0liCD44ck20OAGyLMSymIWTEAtHKVJi6JM18acOnRgUgX7Q65QqnI+sNncNvIy8ew==",
       "dev": true
     },
     "elliptic": {
@@ -30863,19 +30147,19 @@
       }
     },
     "engine.io-client": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
-      "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.4.tgz",
+      "integrity": "sha512-iU4CRr38Fecj8HoZEnFtm2EiKGbYZcPn3cHxqNGl/tmdWRf60KhK+9vE0JeSjgnlS/0oynEfLgKbT9ALpim0sQ==",
       "dev": true,
       "requires": {
         "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
-        "debug": "~4.1.0",
+        "debug": "~3.1.0",
         "engine.io-parser": "~2.2.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
         "ws": "~6.1.0",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
@@ -30888,13 +30172,31 @@
           "dev": true
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "parseqs": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+          "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
+          "dev": true
+        },
+        "parseuri": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+          "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
+          "dev": true
         },
         "ws": {
           "version": "6.1.4",
@@ -30908,14 +30210,14 @@
       }
     },
     "engine.io-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-      "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+      "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
       "dev": true,
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.5",
+        "base64-arraybuffer": "0.1.4",
         "blob": "0.0.5",
         "has-binary2": "~1.0.2"
       }
@@ -30959,21 +30261,21 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0-next.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-      "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
+        "is-callable": "^1.2.2",
         "is-negative-zero": "^2.0.0",
         "is-regex": "^1.1.1",
         "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
       }
@@ -31265,13 +30567,6 @@
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -32092,9 +31387,9 @@
       }
     },
     "karma": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-5.2.2.tgz",
-      "integrity": "sha512-rB3Ua5yDxmIupTj67r3Q8itz7TxJzRE6DmVcOfV20D509Uu9AoBKlVwbZhND4kcm6BqLfbHtv4DZC9QJfrUY+w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-5.2.3.tgz",
+      "integrity": "sha512-tHdyFADhVVPBorIKCX8A37iLHxc6RBRphkSoQ+MLKdAtFn1k97tD8WUGi1KlEtDZKL3hui0qhsY9HXUfSNDYPQ==",
       "dev": true,
       "requires": {
         "body-parser": "^1.19.0",
@@ -32118,7 +31413,7 @@
         "socket.io": "^2.3.0",
         "source-map": "^0.6.1",
         "tmp": "0.2.1",
-        "ua-parser-js": "0.7.21",
+        "ua-parser-js": "0.7.22",
         "yargs": "^15.3.1"
       }
     },
@@ -32990,11 +32285,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "5.1.0",
@@ -33151,13 +32442,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "dev": true,
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -33377,20 +32661,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -33619,9 +32903,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.34",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.34.tgz",
-      "integrity": "sha512-H/7V2VeNScX9KE83GDrDZNiGT1m2H+UTnlinIzhjlLX9hfMUn1mHNnGeX81a1c8JSBdBvqk7c2ZOG6ZPn5itGw==",
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -33682,9 +32966,9 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.3.tgz",
-      "integrity": "sha512-0ClFaY4X1ra21LRqbW6y3rUbWcxnSVkDFG57R7Nxus9J9myPFlv+jYDMohzpkBx0RrjjiqjtycpchQ+PLGmZ9w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+      "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
@@ -34408,6 +33692,12 @@
         "to-array": "0.1.4"
       },
       "dependencies": {
+        "base64-arraybuffer": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+          "dev": true
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -34418,16 +33708,22 @@
           }
         },
         "socket.io-parser": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-          "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
+          "integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
           "dev": true,
           "requires": {
-            "component-emitter": "1.2.1",
+            "component-emitter": "~1.3.0",
             "debug": "~3.1.0",
             "isarray": "2.0.1"
           },
           "dependencies": {
+            "component-emitter": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+              "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+              "dev": true
+            },
             "debug": {
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -34686,20 +33982,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -34717,20 +34013,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -34969,9 +34265,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+      "version": "0.7.22",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
       "dev": true
     },
     "underscore": {
@@ -35358,11 +34654,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",


### PR DESCRIPTION
closes #379 

This patch adds initial support for user session cookies. The OAuth2 'state' parameter is stored in an encrypted and authenticated form in a session cookie that is then validated against the value received in the 'state' query parameter in the callback.

We use the gorilla/sessions module that allows setting an authentication key and an encryption key in order to authenticate and protect the session cookies stored in the browser. These keys are configured as "session cookie keys" and passed in by an admin as variables that point to a file that contains the raw bytes.


Signed-off-by: George Aristy <george.aristy@securekey.com>
