### PR TITLE
fix: Check the user's session cookie before redirecting to the OIDC

### DIFF
--- a/pkg/restapi/oidc/operations.go
+++ b/pkg/restapi/oidc/operations.go
@@ -165,6 +165,13 @@ func (o *Operation) oidcLoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	_, found := session.Get(userSubCookieName)
+	if found {
+		http.Redirect(w, r, o.walletDashboard, http.StatusMovedPermanently)
+
+		return
+	}
+
 	state := uuid.New().String()
 	session.Set(stateCookieName, state)
 	redirectURL := o.oidcClient.FormatRequest(state)

--- a/pkg/restapi/oidc/operations_test.go
+++ b/pkg/restapi/oidc/operations_test.go
@@ -131,6 +131,21 @@ func TestOperation_OIDCLoginHandler(t *testing.T) {
 		o.oidcLoginHandler(w, newOIDCLoginRequest())
 		require.Equal(t, http.StatusInternalServerError, w.Code)
 	})
+
+	t.Run("user already logged in", func(t *testing.T) {
+		o, err := New(config(t))
+		require.NoError(t, err)
+		result := httptest.NewRecorder()
+		o.store.cookies = &cookie.MockStore{
+			Jar: &cookie.MockJar{
+				Cookies: map[interface{}]interface{}{
+					userSubCookieName: uuid.New().String(),
+				},
+			},
+		}
+		o.oidcLoginHandler(result, newOIDCLoginRequest())
+		require.Equal(t, http.StatusMovedPermanently, result.Code)
+	})
 }
 
 func TestOperation_OIDCCallbackHandler(t *testing.T) {


### PR DESCRIPTION
Check the user's session cookie before redirecting to the OIDC.

Closes #497 

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>