### PR TITLE
fix: Increase get credential retries to accommodate slow EDV server

### DIFF
--- a/cmd/wallet-web/src/pages/chapi/wallet/get/getCredentialsByQuery.js
+++ b/cmd/wallet-web/src/pages/chapi/wallet/get/getCredentialsByQuery.js
@@ -274,7 +274,7 @@ async function waitForCredentials(agent, pool) {
 
 
 async function getCredentialMetadata(agent, name) {
-    const retries = 10;
+    const retries = 30; // TODO (#531): Reduce number of retries once EDV storage speed is improved.
     for (let i = 0; i < retries; i++) {
         try {
             return await agent.verifiable.getCredentialByName({


### PR DESCRIPTION
This is a temporary change and will be decreased back down to a more reasonable value in a future commit once EDV server storage speed is improved.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>