### PR TITLE
chore: update hub-kms image

### DIFF
--- a/test/bdd/fixtures/wallet-web/.env
+++ b/test/bdd/fixtures/wallet-web/.env
@@ -73,7 +73,7 @@ MOCK_DEMO_LOGIN_CONSENT_IMAGE=edgeagent/demologinconsent
 
 # KMS Configuration
 HUB_KMS_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/kms-rest
-HUB_KMS_IMAGE_TAG=0.1.5-snapshot-9868bcb
+HUB_KMS_IMAGE_TAG=0.1.5-snapshot-697bc03
 HUB_KMS_HOST=0.0.0.0
 AUTHZ_HUB_KMS_PORT=8076
 OPS_HUB_KMS_PORT=8075

--- a/test/bdd/fixtures/wallet-web/docker-compose.yml
+++ b/test/bdd/fixtures/wallet-web/docker-compose.yml
@@ -590,6 +590,7 @@ services:
       - KMS_SECRETS_DATABASE_TYPE=mem
       - KMS_KEY_MANAGER_STORAGE_TYPE=edv
       - KMS_KEY_MANAGER_STORAGE_URL=https://edv.example.com:${EDV_PORT}
+      - KMS_ZCAP_ENABLE=false # default is false anyway
     ports:
       - ${OPS_HUB_KMS_PORT}:${OPS_HUB_KMS_PORT}
     entrypoint: ""

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/tidwall/gjson v1.6.3
 	github.com/trustbloc/edge-agent v0.0.0
-	github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf
+	github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc
 	gotest.tools/v3 v3.0.2 // indirect
 )
 

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -614,8 +614,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd h1:xoE9iE/ij9qR4LvAP/ubME2dz/7eB6CLhNvK/M1iGrI=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e h1:QluQFRvFRSYExodztwD1RS6bTRcqGZSjTuRpPCrOek0=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=
@@ -1008,6 +1008,8 @@ github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
 github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf h1:D8Q4KRWD64vWd6hgTdGDsWI0s9pEeKbN1eHsr+FVos0=
 github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
+github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc h1:sGjZhZKuOB/x4ZUXkrID05RwVYvHDg5fe5BQhhubE0g=
+github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/trustbloc/edv v0.1.5-0.20201122203913-1dae4015cad6 h1:3afjtOH4EWBzM9L6VWeRPHVE3gAUz22jwXyZSI46vdQ=
 github.com/trustbloc/edv v0.1.5-0.20201122203913-1dae4015cad6/go.mod h1:QpKdT5XtsilAY/7+/724KvKKKsgIca98OoBn9VYpnsY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
This PR **does not** enable ZCAPLD authorization on hub-kms. ZCAPLD authz will be enabled in #543 .

Changes:

* hub-kms: support zcapld authorization https://github.com/trustbloc/hub-kms/pull/108
* go mod tidy

Signed-off-by: George Aristy <george.aristy@securekey.com>