### PR TITLE
refactor: bearer token usage for hub-kms/oathkeeper

### DIFF
--- a/test/bdd/fixtures/wallet-web/docker-compose.yml
+++ b/test/bdd/fixtures/wallet-web/docker-compose.yml
@@ -200,8 +200,8 @@ services:
       - HTTP_SERVER_RP_DISPLAY_NAME=trustbloc
       - HTTP_SERVER_RP_ORIGIN_NAME=https://bddtest-wallet-web.trustbloc.local:8077/
       - HTTP_SERVER_RP_ID=localhost
-      - HTTP_SERVER_AUTHZ_KMS_URL=https://authz-kms.trustbloc.local:${AUTHZ_HUB_KMS_PORT}
-      - HTTP_SERVER_OPS_KMS_URL=https://ops-kms.trustbloc.local:${OPS_HUB_KMS_PORT}
+      - HTTP_SERVER_AUTHZ_KMS_URL=https://bdd-oathkeeper-auth-keyserver.trustbloc.local:4459
+      - HTTP_SERVER_OPS_KMS_URL=https://bdd-oathkeeper-ops-keyserver.trustbloc.local:4460
       - HTTP_SERVER_KEY_EDV_URL=https://bdd-edv-oathkeeper-proxy:4457/encrypted-data-vaults
       - HTTP_SERVER_USER_EDV_URL=https://bdd-edv-oathkeeper-proxy:4457/encrypted-data-vaults
       - ARIESD_LOG_LEVEL=DEBUG
@@ -665,4 +665,40 @@ services:
     restart: on-failure
     volumes:
       - ../bdd-edv-oathkeeper:/oathkeeper
+      - ../keys/tls:/etc/tls
+
+  bdd-oathkeeper-auth-keyserver.trustbloc.local:
+    container_name: bdd-oathkeeper-auth-keyserver.trustbloc.local
+    image: oryd/oathkeeper:v0.38.4-alpine
+    ports:
+      - 4459:4459
+    command: /bin/sh -c "cp /etc/tls/ec-cacert.pem /usr/local/share/ca-certificates/;update-ca-certificates;oathkeeper serve proxy --config /oathkeeper/config.yaml"
+    user: root
+    entrypoint: ""
+    environment:
+      - LOG_LEVEL=debug
+      - PORT=4459
+      - ISSUER_URL=https://bdd-oathkeeper-auth-keyserver:4459
+      - SERVE_PROXY_TLS_KEY_PATH=/etc/tls/ec-key.pem
+      - SERVE_PROXY_TLS_CERT_PATH=/etc/tls/ec-pubCert.pem
+    volumes:
+      - ./oathkeeper-config/auth-keyserver:/oathkeeper
+      - ../keys/tls:/etc/tls
+
+  bdd-oathkeeper-ops-keyserver.trustbloc.local:
+    container_name: bdd-oathkeeper-ops-keyserver.trustbloc.local
+    image: oryd/oathkeeper:v0.38.4-alpine
+    ports:
+      - 4460:4460
+    command: /bin/sh -c "cp /etc/tls/ec-cacert.pem /usr/local/share/ca-certificates/;update-ca-certificates;oathkeeper serve proxy --config /oathkeeper/config.yaml"
+    user: root
+    entrypoint: ""
+    environment:
+      - LOG_LEVEL=debug
+      - PORT=4460
+      - ISSUER_URL=https://bdd-oathkeeper-ops-keyserver:4460
+      - SERVE_PROXY_TLS_KEY_PATH=/etc/tls/ec-key.pem
+      - SERVE_PROXY_TLS_CERT_PATH=/etc/tls/ec-pubCert.pem
+    volumes:
+      - ./oathkeeper-config/ops-keyserver:/oathkeeper
       - ../keys/tls:/etc/tls

--- a/test/bdd/fixtures/wallet-web/oathkeeper-config/auth-keyserver/config.yaml
+++ b/test/bdd/fixtures/wallet-web/oathkeeper-config/auth-keyserver/config.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+serve:
+  proxy:
+    port: 4459
+  api:
+    port: 4458
+
+access_rules:
+  repositories:
+    - file:///oathkeeper/rules/resource-server.json
+  matching_strategy: glob
+
+authenticators:
+  oauth2_introspection:
+    enabled: true
+    config:
+      introspection_url: https://bdd-hub-auth-hydra.trustbloc.local:8889/oauth2/introspect
+  noop:
+    enabled: true
+
+authorizers:
+  allow:
+    enabled: true
+
+mutators:
+  header:
+    enabled: true
+    config:
+      headers:
+        HUB-KMS-USER: '{{ print .Subject }}'
+  noop:
+    enabled: true

--- a/test/bdd/fixtures/wallet-web/oathkeeper-config/auth-keyserver/rules/resource-server.json
+++ b/test/bdd/fixtures/wallet-web/oathkeeper-config/auth-keyserver/rules/resource-server.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "auth-kms-create-keystore",
+    "upstream": {
+      "url": "https://authz-kms.trustbloc.local:8076"
+    },
+    "match": {
+      "url": "https://bdd-oathkeeper-auth-keyserver.trustbloc.local:4459/kms/keystores",
+      "methods": ["POST"]
+    },
+    "authenticators": [{
+      "handler": "oauth2_introspection"
+    }],
+    "mutators": [
+      {
+        "handler": "header",
+        "config": {
+          "headers": {
+            "Hub-Kms-User": "{{ print .Subject }}"
+          }
+        }
+      }
+    ],
+    "authorizer": {
+      "handler": "allow"
+    }
+  },
+  {
+    "id": "auth-kms-keystore-ops",
+    "upstream": {
+      "url": "https://authz-kms.trustbloc.local:8076"
+    },
+    "match": {
+      "url": "https://bdd-oathkeeper-auth-keyserver.trustbloc.local:4459/kms/keystores/<*>",
+      "methods": ["POST", "GET"]
+    },
+    "authenticators": [{
+      "handler": "oauth2_introspection"
+    }],
+    "mutators": [
+      {
+        "handler": "header",
+        "config": {
+          "headers": {
+            "Hub-Kms-User": "{{ print .Subject }}"
+          }
+        }
+      }
+    ],
+    "authorizer": {
+      "handler": "allow"
+    }
+  },
+  {
+    "id": "ops-kms-health",
+    "upstream": {
+      "url": "https://authz-kms.trustbloc.local:8076"
+    },
+    "match": {
+      "url": "http://bdd-oathkeeper-auth-keyserver.trustbloc.local:4459/healthcheck",
+      "methods": ["GET"]
+    },
+    "authenticators": [{
+      "handler": "noop"
+    }],
+    "mutators": [{
+      "handler": "noop"
+    }],
+    "authorizer": {
+      "handler": "allow"
+    }
+  }
+]

--- a/test/bdd/fixtures/wallet-web/oathkeeper-config/ops-keyserver/config.yaml
+++ b/test/bdd/fixtures/wallet-web/oathkeeper-config/ops-keyserver/config.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+serve:
+  proxy:
+    port: 4460
+  api:
+    port: 4458
+
+access_rules:
+  repositories:
+    - file:///oathkeeper/rules/resource-server.json
+  matching_strategy: glob
+
+authenticators:
+  oauth2_introspection:
+    enabled: true
+    config:
+      introspection_url: https://bdd-hub-auth-hydra.trustbloc.local:8889/oauth2/introspect
+  noop:
+    enabled: true
+
+authorizers:
+  allow:
+    enabled: true
+
+mutators:
+  header:
+    enabled: true
+    config:
+      headers:
+        HUB-KMS-USER: '{{ print .Subject }}'
+  noop:
+    enabled: true

--- a/test/bdd/fixtures/wallet-web/oathkeeper-config/ops-keyserver/rules/resource-server.json
+++ b/test/bdd/fixtures/wallet-web/oathkeeper-config/ops-keyserver/rules/resource-server.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "ops-kms-create-keystore",
+    "upstream": {
+      "url": "https://ops-kms.trustbloc.local:8075"
+    },
+    "match": {
+      "url": "https://bdd-oathkeeper-ops-keyserver.trustbloc.local:4460/kms/keystores",
+      "methods": ["POST"]
+    },
+    "authenticators": [{
+      "handler": "oauth2_introspection"
+    }],
+    "mutators": [{
+      "handler": "noop"
+    }],
+    "authorizer": {
+      "handler": "allow"
+    }
+  },
+  {
+    "id": "ops-kms-keystore-ops",
+    "upstream": {
+      "url": "https://ops-kms.trustbloc.local:8075"
+    },
+    "match": {
+      "url": "https://bdd-oathkeeper-ops-keyserver.trustbloc.local:4460/kms/keystores/<*>",
+      "methods": ["POST", "GET"]
+    },
+    "authenticators": [{
+      "handler": "noop"
+    }],
+    "mutators": [{
+      "handler": "noop"
+    }],
+    "authorizer": {
+      "handler": "allow"
+    }
+  },
+  {
+    "id": "ops-kms-health",
+    "upstream": {
+      "url": "https://ops-kms.trustbloc.local:8075"
+    },
+    "match": {
+      "url": "http://bdd-oathkeeper-ops-keyserver.trustbloc.local:4460/healthcheck",
+      "methods": ["GET"]
+    },
+    "authenticators": [{
+      "handler": "noop"
+    }],
+    "mutators": [{
+      "handler": "noop"
+    }],
+    "authorizer": {
+      "handler": "allow"
+    }
+  }
+]


### PR DESCRIPTION
:warning: **this will break edge-agent in the sandbox until PR trustbloc/edge-sandbox#681 is merged** :warning: 

Oathkeeper expects the token in plain form instead of base64-encoding as per https://tools.ietf.org/html/rfc6750#section-2.1.

Signed-off-by: George Aristy <george.aristy@securekey.com>