### PR TITLE
fix: use KMS capability for OPS keyserver operations

### DIFF
--- a/cmd/wallet-server/go.sum
+++ b/cmd/wallet-server/go.sum
@@ -633,6 +633,7 @@ github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb h1:GbE4c+PWz8xZPcZwmKd6jrS8Iwo0j1GJs2UszBbfJTw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -941,6 +942,8 @@ github.com/rogpeppe/go-internal v1.3.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.4.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -1059,6 +1062,8 @@ github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc h1:sGjZhZKuO
 github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/trustbloc/edv v0.1.5-0.20201129165709-60c7f39d8096 h1:ESB0p3PtPd6zystFIItjAaUSmbuR6vwuY5Vtm7bYdFg=
 github.com/trustbloc/edv v0.1.5-0.20201129165709-60c7f39d8096/go.mod h1:BTLxagWOLIDTqSqZUjdX2kYSBFsiPomf49qkBCVEOvE=
+github.com/trustbloc/hub-kms v0.1.5-0.20201202193117-d87fc7d3bef6 h1:fI91UJdL0oJTH6JfRYnojcUKa0OaXvUOfg680st64ts=
+github.com/trustbloc/hub-kms v0.1.5-0.20201202193117-d87fc7d3bef6/go.mod h1:tG3K06yehfFMBWPAnr6Xba/PDhlnfH/+b+COCrQUOCs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=

--- a/cmd/wallet-web/package-lock.json
+++ b/cmd/wallet-web/package-lock.json
@@ -1046,9 +1046,9 @@
       }
     },
     "@trustbloc-cicd/agent-sdk": {
-      "version": "0.1.5-snapshot-b4bb12d",
-      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk/0.1.5-snapshot-b4bb12d/a1d167df73056644b6847d13d9be3bafd84f356ecc95ebca4fdd9da1c7ed6360",
-      "integrity": "sha512-lz1aHPJi/oKnsrPEbNlA2ZE4PlxdVcULAbIWLjxvgk+c5qMfTn2AfJLPqnI6I+CVk/n1/pc4WZUo+oZib1poHw==",
+      "version": "0.1.5-snapshot-1e15720",
+      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk/0.1.5-snapshot-1e15720/68f1ba93f717167de1dbc03a86d00bec9da88b2f0f41f1babab4ddb2379ad282",
+      "integrity": "sha512-4TAbsEsYRRuhESIw35uAoIs7l4+6XK9rjJbi7thUhyqpbV/3sintV0XiLyh7hKEXA50QDridWVGeuQqn4aGaDQ==",
       "requires": {
         "axios": "0.20.0",
         "generate-export-aliases": "^1.1.0",

--- a/cmd/wallet-web/package.json
+++ b/cmd/wallet-web/package.json
@@ -9,7 +9,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@trustbloc-cicd/agent-sdk": "0.1.5-snapshot-b4bb12d",
+    "@trustbloc-cicd/agent-sdk": "0.1.5-snapshot-1e15720",
     "ajv": "^6.12.2",
     "core-js": "^3.4.3",
     "credential-handler-polyfill": "^2.1.0",

--- a/cmd/wallet-web/src/store/modules/options.js
+++ b/cmd/wallet-web/src/store/modules/options.js
@@ -35,6 +35,7 @@ let defaultAgentStartupOpts = {
     edvClearCache: '',
     edvBatchLimit: 0,
     edvBatchTime: '',
+    opsKMSCapability: '',
 }
 
 export default {
@@ -95,6 +96,7 @@ export default {
 
                             agentOpts.authzKeyStoreURL = resp.data.bootstrap.authzKeyStoreURL
                             agentOpts.userConfig = resp.data.userConfig
+                            agentOpts.opsKMSCapability = resp.data.bootstrap.opsKMSCapability
                         })
                         .catch(err => {
                             console.log("error fetching user info: errMsg=", err);
@@ -133,6 +135,7 @@ export default {
                 edvHMACKIDURL: ('edvHMACKIDURL' in agentOpts) ? agentOpts['edvHMACKIDURL'] : defaultAgentStartupOpts['edvHMACKIDURL'],
                 edvBatchLimit: ('edvBatchLimit' in agentOpts) ? agentOpts['edvBatchLimit'] : defaultAgentStartupOpts['edvBatchLimit'],
                 edvBatchTime: ('edvBatchTime' in agentOpts) ? agentOpts['edvBatchTime'] : defaultAgentStartupOpts['edvBatchTime'],
+                opsKMSCapability: ('opsKMSCapability' in agentOpts) ? agentOpts['opsKMSCapability'] : defaultAgentStartupOpts['opsKMSCapability'],
             })
         },
     },

--- a/docs/test/test.md
+++ b/docs/test/test.md
@@ -39,6 +39,8 @@ You need to modify your hosts file (`/etc/hosts` on \*NIX) to add the following 
     127.0.0.1 edv-oathkeeper-proxy
     127.0.0.1 bdd-edv-oathkeeper-proxy
     127.0.0.1 ops-kms.trustbloc.local
+    127.0.0.1 demo-oathkeeper-auth-keyserver.trustbloc.local
+    127.0.0.1 demo-oathkeeper-ops-keyserver.trustbloc.local
 
 ## Running BDD tests
 

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,11 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/sessions v1.2.1
 	github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb
+	github.com/igor-pavlenko/httpsignatures-go v0.0.21
 	github.com/stretchr/testify v1.6.1
 	github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc
 	github.com/trustbloc/edv v0.1.5-0.20201129165709-60c7f39d8096
+	github.com/trustbloc/hub-kms v0.1.5-0.20201202193117-d87fc7d3bef6
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 )
 

--- a/go.sum
+++ b/go.sum
@@ -642,6 +642,7 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b h1:MhwszjbbQXBheiqs+yBbPTRCTy2GTOW+Pkc6cYFa6Sg=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb h1:GbE4c+PWz8xZPcZwmKd6jrS8Iwo0j1GJs2UszBbfJTw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -946,6 +947,8 @@ github.com/rogpeppe/go-internal v1.3.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.4.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -1060,6 +1063,8 @@ github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc h1:sGjZhZKuO
 github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/trustbloc/edv v0.1.5-0.20201129165709-60c7f39d8096 h1:ESB0p3PtPd6zystFIItjAaUSmbuR6vwuY5Vtm7bYdFg=
 github.com/trustbloc/edv v0.1.5-0.20201129165709-60c7f39d8096/go.mod h1:BTLxagWOLIDTqSqZUjdX2kYSBFsiPomf49qkBCVEOvE=
+github.com/trustbloc/hub-kms v0.1.5-0.20201202193117-d87fc7d3bef6 h1:fI91UJdL0oJTH6JfRYnojcUKa0OaXvUOfg680st64ts=
+github.com/trustbloc/hub-kms v0.1.5-0.20201202193117-d87fc7d3bef6/go.mod h1:tG3K06yehfFMBWPAnr6Xba/PDhlnfH/+b+COCrQUOCs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=

--- a/pkg/restapi/oidc/models.go
+++ b/pkg/restapi/oidc/models.go
@@ -41,6 +41,7 @@ type BootstrapData struct {
 	EDVOpsKIDURL      string `json:"edvOpsKIDURL,omitempty"`
 	EDVHMACKIDURL     string `json:"edvHMACKIDURL,omitempty"`
 	UserEDVCapability string `json:"edvCapability,omitempty"`
+	OPSKMSCapability  string `json:"opsKMSCapability,omitempty"` // TODO remove this
 }
 
 type userBootstrapData struct {
@@ -58,6 +59,6 @@ type hubKMSHeader struct {
 }
 
 type userConfig struct {
-	Sub         string `json:"sub,omitempty"`
+	AccessToken string `json:"accessToken,omitempty"`
 	SecretShare string `json:"walletSecretShare,omitempty"`
 }

--- a/pkg/restapi/oidc/operations_test.go
+++ b/pkg/restapi/oidc/operations_test.go
@@ -8,7 +8,9 @@ package oidc // nolint:testpackage // changing to different package requires exp
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -236,6 +238,7 @@ func TestOperation_OIDCCallbackHandler(t *testing.T) { //nolint: gocritic,gocogn
 				}
 
 				statusCode := http.StatusCreated
+				body := ioutil.NopCloser(bytes.NewReader([]byte("{}")))
 
 				if strings.Contains(req.URL.Path, "/export") ||
 					strings.Contains(req.URL.Path, "/sign") ||
@@ -243,8 +246,14 @@ func TestOperation_OIDCCallbackHandler(t *testing.T) { //nolint: gocritic,gocogn
 					statusCode = http.StatusOK
 				}
 
+				if strings.Contains(req.URL.Path, "/export") {
+					body = ioutil.NopCloser(bytes.NewReader(marshal(t, exportKeyResp{
+						PublicKey: base64.URLEncoding.EncodeToString(pubEd25519Key(t)),
+					})))
+				}
+
 				return &http.Response{
-					StatusCode: statusCode, Body: ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+					StatusCode: statusCode, Body: body,
 				}, nil
 			},
 		}
@@ -702,9 +711,17 @@ func TestOperation_OIDCCallbackHandler(t *testing.T) { //nolint: gocritic,gocogn
 					statusCode = http.StatusOK
 				}
 
+				body := ioutil.NopCloser(bytes.NewReader([]byte("{}")))
+
+				if strings.Contains(req.URL.Path, "/export") {
+					body = ioutil.NopCloser(bytes.NewReader(marshal(t, exportKeyResp{
+						PublicKey: base64.URLEncoding.EncodeToString(pubEd25519Key(t)),
+					})))
+				}
+
 				return &http.Response{
 					StatusCode: statusCode,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+					Body:       body,
 				}, nil
 			},
 		}
@@ -740,9 +757,17 @@ func TestOperation_OIDCCallbackHandler(t *testing.T) { //nolint: gocritic,gocogn
 					statusCode = http.StatusInternalServerError
 				}
 
+				body := ioutil.NopCloser(bytes.NewReader([]byte("{}")))
+
+				if strings.Contains(req.URL.Path, "/export") {
+					body = ioutil.NopCloser(bytes.NewReader(marshal(t, exportKeyResp{
+						PublicKey: base64.URLEncoding.EncodeToString(pubEd25519Key(t)),
+					})))
+				}
+
 				return &http.Response{
 					StatusCode: statusCode,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+					Body:       body,
 				}, nil
 			},
 		}
@@ -791,9 +816,17 @@ func TestOperation_OIDCCallbackHandler(t *testing.T) { //nolint: gocritic,gocogn
 					}
 				}
 
+				body := ioutil.NopCloser(bytes.NewReader([]byte("{}")))
+
+				if strings.Contains(req.URL.Path, "/export") {
+					body = ioutil.NopCloser(bytes.NewReader(marshal(t, exportKeyResp{
+						PublicKey: base64.URLEncoding.EncodeToString(pubEd25519Key(t)),
+					})))
+				}
+
 				return &http.Response{
 					StatusCode: statusCode,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+					Body:       body,
 				}, nil
 			},
 		}
@@ -842,9 +875,17 @@ func TestOperation_OIDCCallbackHandler(t *testing.T) { //nolint: gocritic,gocogn
 					}
 				}
 
+				body := ioutil.NopCloser(bytes.NewReader([]byte("{}")))
+
+				if strings.Contains(req.URL.Path, "/export") {
+					body = ioutil.NopCloser(bytes.NewReader(marshal(t, exportKeyResp{
+						PublicKey: base64.URLEncoding.EncodeToString(pubEd25519Key(t)),
+					})))
+				}
+
 				return &http.Response{
 					StatusCode: statusCode,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+					Body:       body,
 				}, nil
 			},
 		}
@@ -877,9 +918,17 @@ func TestOperation_OIDCCallbackHandler(t *testing.T) { //nolint: gocritic,gocogn
 					statusCode = http.StatusOK
 				}
 
+				body := ioutil.NopCloser(bytes.NewReader([]byte("{}")))
+
+				if strings.Contains(req.URL.Path, "/export") {
+					body = ioutil.NopCloser(bytes.NewReader(marshal(t, exportKeyResp{
+						PublicKey: base64.URLEncoding.EncodeToString(pubEd25519Key(t)),
+					})))
+				}
+
 				return &http.Response{
 					StatusCode: statusCode,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+					Body:       body,
 				}, nil
 			},
 		}
@@ -1256,6 +1305,15 @@ func key(t *testing.T) []byte {
 	require.Equal(t, 32, n)
 
 	return key
+}
+
+func pubEd25519Key(t *testing.T) []byte {
+	t.Helper()
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	return pub
 }
 
 func marshal(t *testing.T, v interface{}) []byte {

--- a/pkg/restapi/oidc/webkms.go
+++ b/pkg/restapi/oidc/webkms.go
@@ -1,0 +1,88 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oidc
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+)
+
+type zcapRemoteKMS struct {
+}
+
+func (r *zcapRemoteKMS) Create(kms.KeyType) (string, interface{}, error) {
+	return "", nil, errors.New("zcapRemoteKMS: Create() not implemented")
+}
+
+func (r *zcapRemoteKMS) Get(keyID string) (interface{}, error) {
+	return keyID, nil
+}
+
+func (r *zcapRemoteKMS) Rotate(kms.KeyType, string) (string, interface{}, error) {
+	return "", nil, errors.New("zcapRemoteKMS: Rotate() not implemented")
+}
+
+func (r *zcapRemoteKMS) ExportPubKeyBytes(string) ([]byte, error) {
+	return nil, errors.New("zcapRemoteKMS: ExportPubKeyBytes() not implemented")
+}
+
+func (r *zcapRemoteKMS) CreateAndExportPubKeyBytes(kms.KeyType) (string, []byte, error) {
+	return "", nil, errors.New("zcapRemoteKMS: CreateAndExportPubKeyBytes() not implemented")
+}
+
+func (r *zcapRemoteKMS) PubKeyBytesToHandle([]byte, kms.KeyType) (interface{}, error) {
+	return nil, errors.New("zcapRemoteKMS: PubKeyBytesToHandle() not implemented")
+}
+
+func (r *zcapRemoteKMS) ImportPrivateKey(interface{}, kms.KeyType, ...kms.PrivateKeyOpts) (string, interface{}, error) {
+	return "", nil, errors.New("zcapRemoteKMS: ImportPrivateKey() not implemented")
+}
+
+type zcapRemoteCrypto struct {
+	signer signer
+}
+
+func (r *zcapRemoteCrypto) Encrypt(_, _ []byte, _ interface{}) ([]byte, []byte, error) {
+	return nil, nil, errors.New("zcapRemoteCrypto: Encrypt() not implemented")
+}
+
+func (r *zcapRemoteCrypto) Decrypt(_, _, _ []byte, _ interface{}) ([]byte, error) {
+	return nil, errors.New("zcapRemoteCrypto: Decrypt() not implemented")
+}
+
+func (r *zcapRemoteCrypto) Sign(msg []byte, _ interface{}) ([]byte, error) {
+	sig, err := r.signer.Sign(msg)
+	if err != nil {
+		return nil, fmt.Errorf("zcapRemoteCrypto: signer failed to sign: %w", err)
+	}
+
+	return sig, nil
+}
+
+func (r *zcapRemoteCrypto) Verify(_, _ []byte, _ interface{}) error {
+	return errors.New("zcapRemoteCrypto: Verify() not implemented")
+}
+
+func (r *zcapRemoteCrypto) ComputeMAC([]byte, interface{}) ([]byte, error) {
+	return nil, errors.New("zcapRemoteCrypto: ComputeMAC() not implemented")
+}
+
+func (r *zcapRemoteCrypto) VerifyMAC(_, _ []byte, _ interface{}) error {
+	return errors.New("zcapRemoteCrypto: VerifyMAC() not implemented")
+}
+
+func (r *zcapRemoteCrypto) WrapKey(_, _, _ []byte,
+	_ *crypto.PublicKey, _ ...crypto.WrapKeyOpts) (*crypto.RecipientWrappedKey, error) {
+	return nil, errors.New("zcapRemoteCrypto: WrapKey() not implemented")
+}
+
+func (r *zcapRemoteCrypto) UnwrapKey(*crypto.RecipientWrappedKey, interface{}, ...crypto.WrapKeyOpts) ([]byte, error) {
+	return nil, errors.New("zcapRemoteCrypto: UnwrapKey() not implemented")
+}

--- a/test/bdd/fixtures/wallet-web/.env
+++ b/test/bdd/fixtures/wallet-web/.env
@@ -73,7 +73,7 @@ MOCK_DEMO_LOGIN_CONSENT_IMAGE=edgeagent/demologinconsent
 
 # KMS Configuration
 HUB_KMS_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/kms-rest
-HUB_KMS_IMAGE_TAG=0.1.5-snapshot-da7ba89
+HUB_KMS_IMAGE_TAG=0.1.5-snapshot-b185b89
 HUB_KMS_HOST=0.0.0.0
 DEMO_AUTHZ_HUB_KMS_PORT=8076
 DEMO_OPS_HUB_KMS_PORT=8075

--- a/test/bdd/fixtures/wallet-web/docker-compose.yml
+++ b/test/bdd/fixtures/wallet-web/docker-compose.yml
@@ -560,8 +560,6 @@ services:
     image: ${HUB_KMS_IMAGE}:${HUB_KMS_IMAGE_TAG}
     environment:
       - KMS_HOST_URL=${HUB_KMS_HOST}:${DEMO_AUTHZ_HUB_KMS_PORT}
-      # TODO use oathkeeper url once its switched
-      - KMS_BASE_URL=https://authz-kms.trustbloc.local:${DEMO_AUTHZ_HUB_KMS_PORT}
       - KMS_TLS_CACERTS=/etc/tls/ec-cacert.pem
       - KMS_TLS_SYSTEMCERTPOOL=true
       - KMS_TLS_SERVE_CERT=/etc/tls/ec-pubCert.pem
@@ -581,6 +579,8 @@ services:
       - KMS_KEY_MANAGER_STORAGE_PREFIX=authzkmskm
       - KMS_HUB_AUTH_URL=https://demo-hub-auth.trustbloc.local:8044
       - KMS_HUB_AUTH_API_TOKEN=test_token
+      - KMS_BASE_URL=https://demo-oathkeeper-auth-keyserver.trustbloc.local:4461
+      - KMS_LOG_LEVEL=debug
     ports:
       - ${DEMO_AUTHZ_HUB_KMS_PORT}:${DEMO_AUTHZ_HUB_KMS_PORT}
     entrypoint: ""
@@ -595,8 +595,6 @@ services:
     image: ${HUB_KMS_IMAGE}:${HUB_KMS_IMAGE_TAG}
     environment:
       - KMS_HOST_URL=${HUB_KMS_HOST}:${DEMO_OPS_HUB_KMS_PORT}
-      # TODO use oathkeeper url once its switched
-      - KMS_BASE_URL=https://ops-kms.trustbloc.local:${DEMO_OPS_HUB_KMS_PORT}
       - KMS_TLS_CACERTS=/etc/tls/ec-cacert.pem
       - KMS_TLS_SERVE_CERT=/etc/tls/ec-pubCert.pem
       - KMS_TLS_SERVE_KEY=/etc/tls/ec-key.pem
@@ -612,7 +610,9 @@ services:
       - KMS_LOCAL_KMS_DATABASE_PREFIX=kmslocal
       - KMS_KEY_MANAGER_STORAGE_TYPE=edv
       - KMS_KEY_MANAGER_STORAGE_URL=https://edv.example.com:${EDV_PORT}
-      - KMS_ZCAP_ENABLE=false # default is false anyway
+      - KMS_ZCAP_ENABLE=true
+      - KMS_BASE_URL=https://demo-oathkeeper-ops-keyserver.trustbloc.local:4462
+      - KMS_LOG_LEVEL=debug
     ports:
       - ${DEMO_OPS_HUB_KMS_PORT}:${DEMO_OPS_HUB_KMS_PORT}
     entrypoint: ""

--- a/test/bdd/fixtures/wallet-web/oathkeeper-config/demo-auth-keyserver/config.yaml
+++ b/test/bdd/fixtures/wallet-web/oathkeeper-config/demo-auth-keyserver/config.yaml
@@ -7,6 +7,16 @@
 serve:
   proxy:
     port: 4461
+    cors:
+      enabled: true
+      allowed_headers:
+        - Content-Type
+        - Authorization
+        - Hub-Kms-Secret
+      allowed_origins:
+        - https://user-ui-agent.example.com:8091
+      allow_credentials: true
+      debug: true
   api:
     port: 4458
 

--- a/test/bdd/fixtures/wallet-web/oathkeeper-config/demo-ops-keyserver/config.yaml
+++ b/test/bdd/fixtures/wallet-web/oathkeeper-config/demo-ops-keyserver/config.yaml
@@ -7,6 +7,19 @@
 serve:
   proxy:
     port: 4462
+    cors:
+      enabled: true
+      allowed_headers:
+        - Content-Type
+        - Authorization
+        - Hub-Kms-Secret
+        - Capability-Invocation
+        - Digest
+        - Signature
+      allowed_origins:
+        - https://user-ui-agent.example.com:8091
+      allow_credentials: true
+      debug: true
   api:
     port: 4458
 

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -912,6 +912,8 @@ github.com/rogpeppe/go-internal v1.3.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.4.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -1016,6 +1018,8 @@ github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc h1:sGjZhZKuO
 github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/trustbloc/edv v0.1.5-0.20201129165709-60c7f39d8096 h1:ESB0p3PtPd6zystFIItjAaUSmbuR6vwuY5Vtm7bYdFg=
 github.com/trustbloc/edv v0.1.5-0.20201129165709-60c7f39d8096/go.mod h1:BTLxagWOLIDTqSqZUjdX2kYSBFsiPomf49qkBCVEOvE=
+github.com/trustbloc/hub-kms v0.1.5-0.20201202193117-d87fc7d3bef6 h1:fI91UJdL0oJTH6JfRYnojcUKa0OaXvUOfg680st64ts=
+github.com/trustbloc/hub-kms v0.1.5-0.20201202193117-d87fc7d3bef6/go.mod h1:tG3K06yehfFMBWPAnr6Xba/PDhlnfH/+b+COCrQUOCs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=

--- a/test/wallet-web/package-lock.json
+++ b/test/wallet-web/package-lock.json
@@ -1087,9 +1087,9 @@
       }
     },
     "@trustbloc-cicd/agent-sdk": {
-      "version": "0.1.5-snapshot-b4bb12d",
-      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk/0.1.5-snapshot-b4bb12d/a1d167df73056644b6847d13d9be3bafd84f356ecc95ebca4fdd9da1c7ed6360",
-      "integrity": "sha512-lz1aHPJi/oKnsrPEbNlA2ZE4PlxdVcULAbIWLjxvgk+c5qMfTn2AfJLPqnI6I+CVk/n1/pc4WZUo+oZib1poHw==",
+      "version": "0.1.5-snapshot-1e15720",
+      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk/0.1.5-snapshot-1e15720/68f1ba93f717167de1dbc03a86d00bec9da88b2f0f41f1babab4ddb2379ad282",
+      "integrity": "sha512-4TAbsEsYRRuhESIw35uAoIs7l4+6XK9rjJbi7thUhyqpbV/3sintV0XiLyh7hKEXA50QDridWVGeuQqn4aGaDQ==",
       "requires": {
         "axios": "0.20.0",
         "generate-export-aliases": "^1.1.0",
@@ -1109,7 +1109,6 @@
     "@trustbloc/wallet-web": {
       "version": "file:../../cmd/wallet-web",
       "requires": {
-        "@trustbloc-cicd/agent-sdk": "0.1.5-snapshot-b4bb12d",
         "ajv": "^6.12.2",
         "core-js": "^3.4.3",
         "credential-handler-polyfill": "^2.1.0",
@@ -2074,23 +2073,120 @@
           "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk/0.1.5-snapshot-b4bb12d/a1d167df73056644b6847d13d9be3bafd84f356ecc95ebca4fdd9da1c7ed6360",
           "integrity": "sha512-lz1aHPJi/oKnsrPEbNlA2ZE4PlxdVcULAbIWLjxvgk+c5qMfTn2AfJLPqnI6I+CVk/n1/pc4WZUo+oZib1poHw==",
           "requires": {
-            "axios": "0.20.0",
             "generate-export-aliases": "^1.1.0",
             "minimist": "^1.2.5"
           },
           "dependencies": {
             "axios": {
-              "version": "0.20.0",
-              "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-              "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+            },
+            "wildcard": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+              "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
+            },
+            "worker-farm": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+              "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
               "requires": {
-                "follow-redirects": "^1.10.0"
+                "errno": "~0.1.7"
               }
             },
-            "follow-redirects": {
-              "version": "1.13.0",
-              "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-              "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+            "wrap-ansi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+              "requires": {
+                "ansi-styles": "^3.2.0"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            },
+            "xtend": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+              "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            },
+            "yargs": {
+              "version": "13.3.2",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+              "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+              "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.2"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                  "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                  "requires": {
+                    "locate-path": "^3.0.0"
+                  }
+                },
+                "locate-path": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                  "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                  "requires": {
+                    "p-locate": "^3.0.0",
+                    "path-exists": "^3.0.0"
+                  }
+                },
+                "p-limit": {
+                  "version": "2.3.0",
+                  "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                  "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                  "requires": {
+                    "p-try": "^2.0.0"
+                  }
+                },
+                "p-locate": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                  "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                  "requires": {
+                    "p-limit": "^2.0.0"
+                  }
+                },
+                "path-exists": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                  "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "13.1.2",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+              "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
             }
           }
         },

--- a/test/wallet-web/package.json
+++ b/test/wallet-web/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "tests for wallet-web vue components",
   "dependencies": {
-    "@trustbloc-cicd/agent-sdk": "0.1.5-snapshot-b4bb12d",
+    "@trustbloc-cicd/agent-sdk": "0.1.5-snapshot-1e15720",
     "@trustbloc/wallet-web": "file:../../cmd/wallet-web",
     "jsonpath": "^1.0.2",
     "vue": "^2.6.11",


### PR DESCRIPTION
closes #546
closes #580 

----

blocked by:
- [X]  https://github.com/trustbloc/hub-kms/pull/123
- [x]  https://github.com/trustbloc/agent-sdk/pull/113

-----

changes:

* use KMS capability for OPS keyserver operations
* update hub-kms image in tests/demo
* enable zcaps authz for hub-kms in tests/demo
* **temporarily sending access_token and ops keyserver zcap to the frontend to enable both key servers to be used there** (see TODO #583 )


Signed-off-by: George Aristy <george.aristy@securekey.com>