### PR TITLE
fix: UI alignment fix

### DIFF
--- a/cmd/wallet-web/src/pages/chapi/Login.vue
+++ b/cmd/wallet-web/src/pages/chapi/Login.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 <template>
-    <div class="viewport">
+    <div class="login-viewport">
         <md-card class="md-layout-item md-size-50 md-small-size-100">
             <md-card-header data-background-color="green">
                 <div class="md-title text-center">Web Wallet Login</div>
@@ -136,7 +136,7 @@ SPDX-License-Identifier: Apache-2.0
            position:absolute;
 
     }
-    .viewport {
+    .login-viewport {
         width: 40%;
         max-width: 100%;
         display: inline-flex;


### PR DESCRIPTION
The changes in the PR https://github.com/trustbloc/edge-agent/pull/597/files#diff-3c022876e10a283b7ec65cfcdc50551303c25d2db0d028ff3db285e903580a85R137-R148 broke the CHAPI window UI screens as the class names were conflicting. Updated the class name to be different from the existing ones

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>