### PR TITLE
feat: Allows using wallet-web-dev-start target for local development

### DIFF
--- a/cmd/wallet-web/package.json
+++ b/cmd/wallet-web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "setup:assets": "bash scripts/setup_assets.sh",
-    "serve": "npm run setup:assets && vue-cli-service serve",
+    "serve": "npm run setup:assets && vue-cli-service serve --port 9098",
     "build": " npm run setup:assets && vue-cli-service build",
     "lint": "vue-cli-service lint"
   },

--- a/cmd/wallet-web/src/store/modules/options.js
+++ b/cmd/wallet-web/src/store/modules/options.js
@@ -20,13 +20,13 @@ let defaultAgentStartupOpts = {
     'log-level': 'debug',
     'indexedDB-namespace': 'agent',
     // default backend server url
-    'edge-agent-server': 'https://localhost:8090',
+    'edge-agent-server': 'https://localhost:9099',
 
     blocDomain: 'testnet.trustbloc.local',
     walletMediatorURL: 'https://localhost:10063',
     blindedRouting: false,
     credentialMediatorURL: '',
-    storageType: `edv`,
+    storageType: `indexedDB`,
     edvServerURL: '',
     edvVaultID: '',
     edvCapability: '',

--- a/test/bdd/fixtures/wallet-web/docker-compose.yml
+++ b/test/bdd/fixtures/wallet-web/docker-compose.yml
@@ -131,6 +131,37 @@ services:
     depends_on:
       - edv.example.com
 
+  user-local-agent.example.com:
+    container_name: user-local-agent.example.com
+    image: ${WALLET_SERVER_IMAGE}:latest
+    environment:
+      - AGENT_UI_URL=https://localhost:9098
+      - HTTP_SERVER_HOST_URL=0.0.0.0:9099
+      - TLS_CERT_FILE=/etc/keys/tls/ec-pubCert.pem
+      - TLS_KEY_FILE=/etc/keys/tls/ec-key.pem
+      - TLS_CACERTS=/etc/keys/tls/ec-cacert.pem
+      - HTTP_SERVER_HUB_AUTH_URL=https://demo-hub-auth.trustbloc.local:8044
+      - HTTP_SERVER_OIDC_OPURL=https://demo-hub-auth-hydra.trustbloc.local:5555/
+      - HTTP_SERVER_OIDC_CLIENTID=client-id
+      - HTTP_SERVER_OIDC_CLIENTSECRET=client-secret
+      - HTTP_SERVER_OIDC_CALLBACK=https://localhost:9099/oidc/callback
+      - HTTP_SERVER_COOKIE_AUTH_KEY=/etc/keys/session_cookies/auth.key
+      - HTTP_SERVER_COOKIE_ENC_KEY=/etc/keys/session_cookies/enc.key
+      - HTTP_SERVER_RP_DISPLAY_NAME=trustbloc
+      - HTTP_SERVER_RP_ORIGIN_NAME=https://localhost:9098/
+      - HTTP_SERVER_RP_ID=localhost
+      - HTTP_SERVER_AUTHZ_KMS_URL=https://demo-oathkeeper-auth-keyserver.trustbloc.local:4461
+      - HTTP_SERVER_OPS_KMS_URL=https://demo-oathkeeper-ops-keyserver.trustbloc.local:4462
+      - HTTP_SERVER_KEY_EDV_URL=https://edv-oathkeeper-proxy:4455/encrypted-data-vaults
+      - HTTP_SERVER_USER_EDV_URL=https://edv-oathkeeper-proxy:4455/encrypted-data-vaults
+    ports:
+      - 9099:9099
+    volumes:
+      - ../keys:/etc/keys
+    command: start
+    depends_on:
+      - edv.example.com
+
   second-user-agent.example.com:
     container_name: second-user-agent.example.com
     image: ${WALLET_SERVER_IMAGE}:latest

--- a/test/bdd/fixtures/wallet-web/hydra-config/demo_auth-rest-hydra_configure.sh
+++ b/test/bdd/fixtures/wallet-web/hydra-config/demo_auth-rest-hydra_configure.sh
@@ -16,5 +16,5 @@ hydra clients create \
     --response-types code,id_token \
     --scope openid,profile,email \
     --skip-tls-verify \
-    --callbacks https://user-agent.example.com:8090/oidc/callback,https://second-user-agent.example.com:8070/oidc/callback
+    --callbacks https://user-agent.example.com:8090/oidc/callback,https://second-user-agent.example.com:8070/oidc/callback,https://localhost:9099/oidc/callback
 echo "Finish creating demo wallet-server clients with hub-auth"

--- a/test/bdd/fixtures/wallet-web/oathkeeper-config/demo-auth-keyserver/config.yaml
+++ b/test/bdd/fixtures/wallet-web/oathkeeper-config/demo-auth-keyserver/config.yaml
@@ -15,6 +15,7 @@ serve:
         - Hub-Kms-Secret
       allowed_origins:
         - https://user-ui-agent.example.com:8091
+        - https://localhost:9098
       allow_credentials: true
       debug: true
   api:

--- a/test/bdd/fixtures/wallet-web/oathkeeper-config/demo-ops-keyserver/config.yaml
+++ b/test/bdd/fixtures/wallet-web/oathkeeper-config/demo-ops-keyserver/config.yaml
@@ -18,6 +18,7 @@ serve:
         - Signature
       allowed_origins:
         - https://user-ui-agent.example.com:8091
+        - https://localhost:9098
       allow_credentials: true
       debug: true
   api:


### PR DESCRIPTION
Allows using `make wallet-web-dev-start` target for local development.
NOTE: All images should be already built. If you need to build them use `make wallet-web-start`

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>