### PR TITLE
feat: wallet didconnect - wait for state complete message

### DIFF
--- a/cmd/wallet-web/src/pages/chapi/wallet/didcomm/blindedRouter.js
+++ b/cmd/wallet-web/src/pages/chapi/wallet/didcomm/blindedRouter.js
@@ -35,31 +35,17 @@ export class BlindedRouter {
 
         console.debug('Sending DID Doc request')
         // request peer DID from other party
-        let payload
-        const retries = 5;
-        // TODO this retry logic to be removed once integration issue with did-exchange state complete update delay is resolved
-        for (let i = 1; i <= retries; i++) {
-            try {
-                payload = await this.agent.messaging.send({
-                    "connection_ID": ConnectionID,
-                    "message_body": {
-                        "@id": uuid(),
-                        "@type": didDocReqMsgType,
-                        "sent_time": new Date().toJSON(),
-                    },
-                    "await_reply": {messageType: didDocReqRespType, timeout: 20000000000}, //TODO (#531): Reduce timeout once EDV storage speed is improved. Note: this value used to be 2 seconds (now it's 20).
-                })
-            } catch (e) {
-                if (!e.message.includes("failed to get reply") || i === retries) {
-                    throw e
-                }
-                await sleep(3000);
-                continue
-            }
-            break
-        }
+        let payload = await this.agent.messaging.send({
+            "connection_ID": ConnectionID,
+            "message_body": {
+                "@id": uuid(),
+                "@type": didDocReqMsgType,
+                "sent_time": new Date().toJSON(),
+            },
+            "await_reply": {messageType: didDocReqRespType, timeout: 20000000000}, //TODO (#531): Reduce timeout once EDV storage speed is improved. Note: this value used to be 2 seconds (now it's 20).
+        })
 
-        if(!payload.response) {
+        if (!payload.response) {
             throw 'no response DID found in did doc response'
         }
 
@@ -110,8 +96,3 @@ async function requestDIDFromMediator(agent, reqDoc) {
     console.error('failed to request DID from router, failed to get connection response')
     throw 'failed to request DID from router, failed to get connection response'
 }
-
-function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
-

--- a/cmd/wallet-web/src/pages/chapi/wallet/get/getCredentialsByQuery.js
+++ b/cmd/wallet-web/src/pages/chapi/wallet/get/getCredentialsByQuery.js
@@ -63,7 +63,7 @@ export class WalletGetByQuery extends WalletGet {
 
     async connect() {
         // make sure mediator is connected
-        await  this.agent.mediator.reconnectAll()
+        await this.agent.mediator.reconnectAll()
     }
 
     async getPresentationSubmission() {
@@ -130,7 +130,7 @@ export class WalletGetByQuery extends WalletGet {
 
 
     async _getAuthorizationCredentials(presentationSubmission) {
-        let rpConn = await this.didExchange.connect(this.invitation[0])
+        let rpConn = await this.didExchange.connect(this.invitation[0], {waitForCompletion: true})
 
         // share peer DID with RP for blinded routing
         await this.blindedRouter.sharePeerDID(rpConn.result)

--- a/test/wallet-web/test/mocks/adapters/issuerAdapter.js
+++ b/test/wallet-web/test/mocks/adapters/issuerAdapter.js
@@ -105,6 +105,18 @@ class Adapter {
             id: res.Properties.connectionID,
             router_connections: await getMediatorConnections(this.agent, true),
         })
+
+        await waitForEvent(this.agent, {
+            type: POST_STATE,
+            stateID: stateCompleted,
+            connectionID: res.Properties.connectionID,
+            topic: topicDidExchangeStates,
+        })
+
+        this.agent.messaging.send({"connection_ID": `${res.Properties.connectionID}`, "message_body": {
+                "@id": uuid(),
+                "@type": 'https://trustbloc.dev/didexchange/1.0/state-complete',
+            }})
     }
 
     /**


### PR DESCRIPTION
- RP will wait for state complete message before proceeding with blinded
routing steps.
- this will save few cycles since this one removes need for having retry
on did doc request.
- closes #611

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>