### PR TITLE
perf: create keys for Trustbloc DID in parallel

### DIFF
--- a/cmd/wallet-web/src/pages/chapi/wallet/didmgmt/didManager.js
+++ b/cmd/wallet-web/src/pages/chapi/wallet/didmgmt/didManager.js
@@ -33,9 +33,11 @@ export class DIDManager extends KeyValueStore {
 
         let generateKeyType = keyTypeIndex.get(keyType)
 
-        const keySet = await this.agent.kms.createKeySet({keyType: generateKeyType})
-        const recoveryKeySet = await this.agent.kms.createKeySet({keyType: generateKeyType})
-        const updateKeySet = await this.agent.kms.createKeySet({keyType: generateKeyType})
+        const [keySet, recoveryKeySet, updateKeySet] = await Promise.all([
+            this.agent.kms.createKeySet({keyType: generateKeyType}),
+            this.agent.kms.createKeySet({keyType: generateKeyType}),
+            this.agent.kms.createKeySet({keyType: generateKeyType})
+        ])
 
         const createDIDRequest = {
             "publicKeys": [{


### PR DESCRIPTION
This PR updates code so the creation of keys for Trustbloc DID is done in parallel. This cuts around 1s from "assign DID" part of "Sign Up" flow.

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>