### PR TITLE
chore: update package-lock.json with latest agent-sdk revision

### DIFF
--- a/test/wallet-web/package-lock.json
+++ b/test/wallet-web/package-lock.json
@@ -1110,7 +1110,7 @@
       "version": "file:../../cmd/wallet-web",
       "requires": {
         "@saeris/vue-spinners": "^1.0.8",
-        "@trustbloc-cicd/agent-sdk": "0.1.6-snapshot-3a6db5f",
+        "@trustbloc-cicd/agent-sdk": "0.1.6-snapshot-84b797f",
         "ajv": "^6.12.2",
         "core-js": "^3.4.3",
         "credential-handler-polyfill": "^2.1.0",
@@ -2077,9 +2077,9 @@
           }
         },
         "@trustbloc-cicd/agent-sdk": {
-          "version": "0.1.6-snapshot-3a6db5f",
-          "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk/0.1.6-snapshot-3a6db5f/916ef76200f64ff2389fe8067422e917c548de45c46af62295a3fdc74808fc24",
-          "integrity": "sha512-QDCo2RuiT+7Oj974OC8wHoNjrOavgHOdi8wtJchTxYGyfnmF/B+7EQcWzcVS46WzNFykOgvDMsfOi1mJB1IXbg==",
+          "version": "0.1.6-snapshot-84b797f",
+          "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk/0.1.6-snapshot-84b797f/82532a91d8895c892687c6702a08e64c0c475fef28104a6cdd4ac1c4a0d34c6b",
+          "integrity": "sha512-pBRaaMPDaF8OBx8cjh7N0A+kzEVxFeU4xKS7B0eHJbgrhQuK4xxTk9W0kJ87kjGpXBBf5RHMtBizQ/wUpi3ilg==",
           "requires": {
             "axios": "0.20.0",
             "generate-export-aliases": "^1.1.0",


### PR DESCRIPTION
following the latest agent-sdk revision update, the lock file was missing this update as well

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>