### PR TITLE
fix: EDV Docker image version

### DIFF
--- a/test/bdd/fixtures/wallet-web/.env
+++ b/test/bdd/fixtures/wallet-web/.env
@@ -54,7 +54,7 @@ COUCHDB_PASSWORD=password
 
 # EDV configurations
 EDV_REST_IMAGE=ghcr.io/trustbloc-cicd/edv
-EDV_REST_IMAGE_TAG=0.1.6-snapshot-2d865e5
+EDV_REST_IMAGE_TAG=0.1.6-snapshot-46a56ab
 EDV_HOST=0.0.0.0
 EDV_PORT=8072
 EDV_DATABASE_TYPE=couchdb


### PR DESCRIPTION
The EDV Docker image was accidentally rolled back to an older version in a previous commit. This updates it to the correct, latest version.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>