### PR TITLE
feat: Remove beat loader and add demo-provider icon and updated ui

### DIFF
--- a/cmd/wallet-web/src/assets/img/demo_provider.svg
+++ b/cmd/wallet-web/src/assets/img/demo_provider.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2585db40d29188790896b27808202d9dcea563588d9eaf11395570176b1f1a7
+size 445

--- a/cmd/wallet-web/src/pages/chapi/Signup.vue
+++ b/cmd/wallet-web/src/pages/chapi/Signup.vue
@@ -2,15 +2,15 @@
   <div class="bg-neutrals-softWhite flex  min-w-screen min-h-screen items-center justify-center px-5 py-5
               bg-scroll lg:bg-onboarding xl:bg-onboarding xs:bg-onboarding sm:bg-onboarding 2xl:bg-onboarding md:bg-onboarding bg-no-repeat">
     <div class="bg-gradient-dark rounded-xl overflow-hidden text-neutrals-softWhite text-xl md:text-3xl
-    2xl:h-xl 2xl:w-xl xl:h-xl xl:w-xl sm:h-xl sm:w-xl md:h-xl md:w-xl h-fit-content w-full -mt-40 sm:-mt-56 xs:-mt-56 lg:mt-0 2xl:mt-0 xl:mt-0 md:mt-10">
+    2xl:h-full 2xl:w-xl xl:h-full xl:w-xl sm:h-full sm:w-xl md:h-full md:w-xl w-full -mt-40 sm:-mt-56 xs:-mt-56 lg:mt-0 2xl:mt-0 xl:mt-0 md:mt-10">
       <!--Trustbloc Intro div  -->
       <div class="grid 2xl:grid-cols-2 lg:grid-cols-2 md:grid-cols-2 sm:grid-cols-1 xs:grid-cols-1
-           bg-flare bg-no-repeat w-auto h-auto lg:divide-x md:divide-x divide-neutrals-medium divide-opacity-25">
+           bg-flare bg-no-repeat w-auto h-3/5 divide-x divide-neutrals-medium divide-opacity-25">
         <div class="col-span-1 hidden xl:block 2xl:block lg:block md:block py-14 px-8">
           <ul class="list-none md:list-disc text-sm px-4 py-4">
             <div class="flex items-center">
               <img class="h-2 w-8 mr-2 mt-4 md-4 my-2 mx-4" src="@/assets/img/logo.svg">
-              <h2 class="font-bold text-4xl lg:text-3xl">TrustBloc</h2>
+              <h2 class="font-bold text-4xl lg:text-6xl">TrustBloc</h2>
             </div>
             <ul class="w-full rounded-lg mt-2 mb-3 font-normal">
               <li class="pl-3 pr-4 py-3 text-sm">
@@ -36,23 +36,17 @@
           </ul>
         </div>
         <!--Trustbloc Sign-up provider div -->
-        <div class="col-span-1 md:block sm:object-none sm:object-center md:py-18 lg:px-4 xl:py-14 xl:px-4 lg:py-14 ">
+        <div class="col-span-1 md:block sm:object-none sm:object-center md:py-18 lg:px-4 xl:py-14 xl:px-4 lg:py-14">
           <div class="flex justify-center items-center lg:hidden md:hidden xl:hidden xs:block sm:block ">
             <img class="h-4 w-8 mr-1 mt-4 md-4 my-2" src="@/assets/img/logo.svg">
             <h2 class="font-bold text-8xl lg:text-2xl md:text-4xl sm:text-6xl xs:text-8xl">TrustBloc</h2>
           </div>
           <div class="text-center items-center mb-10">
-            <h1 class="font-bold text-3xl 2xl:text-lg lg:text-2xl md:text-4xl sm:text-6xl xs:text-8xl text-neutrals-softWhite">Sign up. It's free!
+            <h1 class="font-bold text-3xl 2xl:text-4xl lg:text-2xl md:text-4xl sm:text-6xl xs:text-8xl text-neutrals-softWhite">Sign up. It's free!
             </h1>
           </div>
-           <md-card-content v-if="loading" style="margin: 10% 20% 10% 30%">
-              <beat-loader :color="'white'" :size="20"></beat-loader>
-              <transition name="fade" mode="out-in">
-                <div class="text-white" style="padding-top: 10px;" :key="messageNum">{{messages[messageNum]}}</div>
-              </transition>
-            </md-card-content>
-            <div class="flex 2xl:mx-8 xl:mx-8 lg:mx-4 md:mx-4 mx-4 -mt-6">
-              <div class="w-full px-8 mb-8 2xl:mr-8 xl:mr-8 lg:mr-8 md:mr-4 sm:mx-2 sm:mb-8 md:mb-8 items-center">
+            <div class="flex 2xl:m-8 xl:mx-8 lg:mx-4 md:mx-4 mx-4 align-middle content-center">
+              <div class="w-full px-8 mb-8 2xl:m-8 xl:m-8 lg:m-8 md:m-4 sm:mx-2 sm:mb-8 md:mb-8">
                 <button class="2xl:flex 2xl:flex-wrap lg:flex lg:flex-wrap md:flex md:flex-wrap text-xs 2xl:text-xs xl:text-xs lg:text-sm
                 md:text-xs sm:text-xl text-center content-center w-full py-2 mb-4 px-6
                         font-bold bg-neutrals-softWhite text-neutrals-dark rounded-md"
@@ -60,7 +54,7 @@
                            v-on:click="beginOIDCLogin(provider.id)">
                   <img class="object-contain inline-block  max-h-4 max-w-2 mr-2"
                        :src="provider.logoURL"/>
-                  Continue with {{ provider.name }}
+                    {{ provider.name }}
                 </button>
               </div>
             </div>
@@ -81,13 +75,11 @@
 import {DeviceLogin, RegisterWallet} from "./wallet"
 import ContentFooter from "@/pages/layout/ContentFooter.vue"
 import {mapActions, mapGetters} from 'vuex'
-import {BeatLoader} from "@saeris/vue-spinners";
 import axios from 'axios';
 
 export default {
   created: async function () {
     await this.fetchProviders()
-    this.startLoading()
     //TODO: issue-601 Implement cookie logic with information from the backend.
     this.deviceLogin = new DeviceLogin(this.getAgentOpts());
     let redirect = this.$route.params['redirect']
@@ -116,12 +108,8 @@ export default {
     if (this.$cookies.isKey('registerSuccess')) {
       this.registered = true;
     }
-
-    this.stopLoading()
-    this.loading = false
   },
   components: {
-    BeatLoader,
     ContentFooter,
   },
   data() {
@@ -195,15 +183,6 @@ export default {
     },
     loginDevice: async function () {
       await this.deviceLogin.login();
-    },
-    startLoading() {
-      this.intervalID = setInterval(() => {
-        this.messageNum++;
-        this.messageNum %= this.messages.length;
-      }, 3000);
-    },
-    stopLoading() {
-      clearInterval(this.intervalID);
     },
 
   }


### PR DESCRIPTION
- Fixed the divider length 
- Add demo provider icon 
- Moved sign up button alignment as per the new screem 
- Removed beat loader 




<img width="1677" alt="Screen Shot 2021-07-08 at 2 37 26 AM" src="https://user-images.githubusercontent.com/7862595/124879010-c18af880-df9a-11eb-914f-0f2d3fcf69eb.png">
Signed-off-by: talwinder kaur <talwinder.kaur@securekey.com>